### PR TITLE
Add new dow3-1.0.2 test profile

### DIFF
--- a/pts/dow3-1.0.2/downloads.xml
+++ b/pts/dow3-1.0.2/downloads.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m4-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://phoronix-test-suite.com/benchmark-files/dow3-prefs-2.zip</URL>
+      <MD5>530bafd7e59f1883277d317e13b936da</MD5>
+      <SHA256>78497f604c8142e67ce1ddb6b56e586ca423261db155a7eaa9d80bae86ddc6e1</SHA256>
+      <FileSize>8170</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/dow3-1.0.2/install.sh
+++ b/pts/dow3-1.0.2/install.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+unzip -o dow3-prefs-2.zip
+
+HOME=$DEBUG_REAL_HOME steam steam://install/285190
+mkdir -p $DEBUG_REAL_HOME/.local/share/feral-interactive/Dawn\ of\ War\ III
+
+echo "#!/bin/bash
+GAME_PREFS=\"\$DEBUG_REAL_HOME/.local/share/feral-interactive/Dawn of War III\"
+. steam-env-vars.sh
+
+# cd \$DEBUG_REAL_HOME/.steam/steam/steamapps/common/Dawn\ of\ War\ III/ || exit
+cd /opt/steam/steamapps/common/Dawn\ of\ War\ III/ || exit
+
+# Run the game as if from steam
+./DawnOfWar3.sh
+
+cd \"\$GAME_PREFS/VFS/User/AppData/Roaming/My Games/Dawn of War III/LogFiles/\"
+cat perfreport*.csv  > \"\$LOG_FILE\"
+" > dow3
+chmod +x dow3

--- a/pts/dow3-1.0.2/interim.sh
+++ b/pts/dow3-1.0.2/interim.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+GAME_PREFS="$DEBUG_REAL_HOME/.local/share/feral-interactive/Dawn of War III"
+
+# Clean out the game temp files to ensure we have a clean run
+rm -rf "${GAME_PREFS:?}/VFS"
+
+# clear previous runs
+rm -rf "$GAME_PREFS/VFS/User/AppData/Roaming/My Games/Dawn of War III/LogFiles/"

--- a/pts/dow3-1.0.2/post.sh
+++ b/pts/dow3-1.0.2/post.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+GAME_PREFS="$DEBUG_REAL_HOME/.local/share/feral-interactive/Dawn of War III"
+
+DATETIME=$( cat /tmp/dow3-bkp-dt )
+rm -f /tmp/dow3-bkp-dt
+GAME_PREFS_BKP="${GAME_PREFS}.$DATETIME.pts-bkp"
+
+rm -rf "${GAME_PREFS:?}/"
+mv "$GAME_PREFS_BKP/" "$GAME_PREFS"

--- a/pts/dow3-1.0.2/pre.sh
+++ b/pts/dow3-1.0.2/pre.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -o xtrace
+exec > /tmp/test
+exec 2>&1
+
+STEAM_GAME_ID=285190
+GAME_BINARY=DawnOfWar3
+WIDTH=$1
+HEIGHT=$2
+SETTING=$3
+VULKAN=$4
+
+export HOME=$DEBUG_REAL_HOME
+GAME_PREFS="$DEBUG_REAL_HOME/.local/share/feral-interactive/Dawn of War III"
+
+# Gather the steam env variables the game runs with
+steam steam://run/$STEAM_GAME_ID &
+sleep 6
+GAME_PID=`pgrep $GAME_BINARY | tail -1`
+echo '#!/bin/sh' > steam-env-vars.sh
+echo "# PID: $GAME_PID" >> steam-env-vars.sh
+while read -d $'\0' ENV; do NAME=`echo $ENV | cut -d= -f1`; VAL=`echo $ENV | cut -d= -f2`; echo "export $NAME=\"$VAL\""; done < /proc/$GAME_PID/environ >> steam-env-vars.sh
+chmod +x steam-env-vars.sh
+
+killall -9 DawnOfWar3
+sleep 6
+
+# Set up (and back up) the game preferences files
+DATETIME=$( date +%Y-%d-%m-%H-%M )
+echo $DATETIME > /tmp/dow3-bkp-dt
+GAME_PREFS_BKP="${GAME_PREFS}.$DATETIME.pts-bkp"
+cp -r "$GAME_PREFS" "$GAME_PREFS_BKP"
+
+# clear previous runs
+rm -rf "$GAME_PREFS/VFS/User/AppData/Roaming/My Games/Dawn of War III/LogFiles/"
+
+# clear out intermediate files
+rm -rf "${GAME_PREFS:?}/VFS/"
+cp "preferences.$SETTING.xml" "$GAME_PREFS/preferences"
+
+cd "$GAME_PREFS" || exit
+sed -i "s/1920/$WIDTH/g" preferences
+sed -i "s/1080/$HEIGHT/g" preferences
+
+if [ "X$VULKAN" = "XVULKAN" ]
+then
+	sed -i  's/<value name="UseVulkan" type="integer">0<\/value>/<value name="UseVulkan" type="integer">1<\/value>/' preferences
+fi
+

--- a/pts/dow3-1.0.2/results-definition.xml
+++ b/pts/dow3-1.0.2/results-definition.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>average fps #_RESULT_#
+minimum fps #_MIN_RESULT_#
+maximum fps #_MAX_RESULT_#</OutputTemplate>
+    <TurnCharsToSpace>,</TurnCharsToSpace>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/dow3-1.0.2/test-definition.xml
+++ b/pts/dow3-1.0.2/test-definition.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Dawn of War III</Title>
+    <Description>Dawn of War III on Steam. The test profile assumes you have a Steam account, have Steam installed for the system, and that you own a copy of this game. This automates the process of executing the game and using its built-in benchmark mode.</Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <IgnoreRuns>1</IgnoreRuns>
+    <TimesToRun>4</TimesToRun>
+    <PreInstallMessage>This test will attempt to install the necessary game using your Steam account. If the test appears hung you may need to manually exit the Steam client.</PreInstallMessage>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.1</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Game</SoftwareType>
+    <TestType>Graphics</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <SupportedArchitectures>x86_64</SupportedArchitectures>
+    <EnvironmentSize>2</EnvironmentSize>
+    <ProjectURL>http://store.steampowered.com/agecheck/app/285190/</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Resolution</DisplayName>
+      <Identifier>auto-resolution</Identifier>
+      <ArgumentPrefix></ArgumentPrefix>
+      <ArgumentPostfix></ArgumentPostfix>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>$VIDEO_WIDTH x $VIDEO_HEIGHT</Name>
+          <Value>$VIDEO_WIDTH $VIDEO_HEIGHT</Value>
+          <Message></Message>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Graphics Preset</DisplayName>
+      <Identifier>graphics-preset</Identifier>
+      <ArgumentPrefix></ArgumentPrefix>
+      <ArgumentPostfix></ArgumentPostfix>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>Min</Name>
+          <Value>min</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>Low</Name>
+          <Value>low</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>Medium</Name>
+          <Value>med</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>High</Name>
+          <Value>hig</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>Ultra</Name>
+          <Value>ult</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>Maximum</Name>
+          <Value>max</Value>
+          <Message></Message>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Renderer</DisplayName>
+      <Identifier>renderer</Identifier>
+      <ArgumentPrefix></ArgumentPrefix>
+      <ArgumentPostfix></ArgumentPostfix>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>OpenGL</Name>
+          <Value>OPENGL</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>Vulkan</Name>
+          <Value>VULKAN</Value>
+          <Message></Message>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
	Changes:
	* Set up the preferences in the pre script, so we only do that once per test
	* Only clean out the temporary game files between runs (preserving the shader cache)
	* Run once to gather a shader cache, and run 4 times to account for that
		this makes the results better reflect user experience
	* Add minimum setting and re-order so max is above ultra (higher in game)
	* Back up the preferences directory and restore it after the run (preserves user game saves)
	* Remove Mad Max from description

	NOTE: This relies on a change to the PTS to pts_tests.php:235 to ensure arguments aren't globbed to pre/post/interim scrips