### PR TITLE
Use the glibc malloc instead of a built-in jemalloc replacement

### DIFF
--- a/pts/redis-1.0.0/install.sh
+++ b/pts/redis-1.0.0/install.sh
@@ -6,7 +6,7 @@ cd ~/redis-3.0.1/deps
 make hiredis jemalloc linenoise lua
 
 cd ~/redis-3.0.1
-make -j $NUM_CPU_JOBS
+make MALLOC=libc -j $NUM_CPU_JOBS
 echo $? > ~/install-exit-status
 
 cd ~


### PR DESCRIPTION
It's more interesting and fair to test the C library malloc() than it is to test jemalloc