### PR TITLE
Fix problematic preference setting code + re-order TAA

### DIFF
--- a/pts/f12017-1.0.0/pre.sh
+++ b/pts/f12017-1.0.0/pre.sh
@@ -145,24 +145,25 @@ cd "$GAME_PREFS" || exit
 sed -i "s/RESOLUTION_WIDTH/$WIDTH/g" preferences
 sed -i "s/RESOLUTION_HEIGHT/$HEIGHT/g" preferences
 sed -i "s/ANTIALIASING/$AA/g" preferences
-sed -i "s/SHADOWS/$gfxconfig_advanced_smoke_shadows/g" preferences
-sed -i "s/OCCLUSION/$gfxconfig_ambient_occlusion/g" preferences
+sed -i "s/ADVANCED_SMOKE_SHADOWS/$gfxconfig_advanced_smoke_shadows/g" preferences
+sed -i "s/AMBIENT_OCCLUSION/$gfxconfig_ambient_occlusion/g" preferences
 sed -i "s/CROWD/$gfxconfig_crowd/g" preferences
-sed -i "s/HAIR/$gfxconfig_dynamic_hair/g" preferences
-sed -i "s/COVER/$gfxconfig_ground_cover/g" preferences
-sed -i "s/MODE/$gfxconfig_hdr_mode/g" preferences
+sed -i "s/DYNAMIC_HAIR/$gfxconfig_dynamic_hair/g" preferences
+sed -i "s/GROUND_COVER/$gfxconfig_ground_cover/g" preferences
+sed -i "s/HDR_MODE/$gfxconfig_hdr_mode/g" preferences
 sed -i "s/LIGHTING/$gfxconfig_lighting/g" preferences
 sed -i "s/MIRRORS/$gfxconfig_mirrors/g" preferences
 sed -i "s/PARTICLES/$gfxconfig_particles/g" preferences
 sed -i "s/POSTPROCESS/$gfxconfig_postprocess/g" preferences
-sed -i "s/REFLECTIONS/$gfxconfig_screen_space_reflections/g" preferences
+sed -i "s/SCREEN_SPACE_REFLECTIONS/$gfxconfig_screen_space_reflections/g" preferences
 sed -i "s/SHADOWS/$gfxconfig_shadows/g" preferences
 sed -i "s/SKIDMARKS/$gfxconfig_skidmarks/g" preferences
-sed -i "s/BLENDING/$gfxconfig_skidmarks_blending/g" preferences
-sed -i "s/SHADOWS/$gfxconfig_smoke_shadows/g" preferences
-sed -i "s/SHADOWS/$gfxconfig_ssrt_shadows/g" preferences
-sed -i "s/STREAMING/$gfxconfig_texture_streaming/g" preferences
-sed -i "s/REFLECTIONS/$gfxconfig_vehicle_reflections/g" preferences
-sed -i "s/EFFECTS/$gfxconfig_weather_effects/g" preferences
+sed -i "s/SKIDMARKS_BLENDING/$gfxconfig_skidmarks_blending/g" preferences
+sed -i "s/SMOKE_SHADOWS/$gfxconfig_smoke_shadows/g" preferences
+sed -i "s/SSSRT_HADOWS/$gfxconfig_ssrt_shadows/g" preferences
+sed -i "s/TEXTURE_STREAMING/$gfxconfig_texture_streaming/g" preferences
+sed -i "s/VEHICLE_REFLECTIONS/$gfxconfig_vehicle_reflections/g" preferences
+sed -i "s/WEATHER_EFFECTS/$gfxconfig_weather_effects/g" preferences
+
 
 

--- a/pts/f12017-1.0.0/test-definition.xml
+++ b/pts/f12017-1.0.0/test-definition.xml
@@ -83,13 +83,13 @@
           <Message></Message>
         </Entry>
         <Entry>
-          <Name>TAA</Name>
-          <Value>taa</Value>
+          <Name>TAA Checkerboard</Name>
+          <Value>taa+checkerboard</Value>
           <Message></Message>
         </Entry>
         <Entry>
-          <Name>TAA Checkerboard</Name>
-          <Value>taa+checkerboard</Value>
+          <Name>TAA</Name>
+          <Value>taa</Value>
           <Message></Message>
         </Entry>
       </Menu>


### PR DESCRIPTION
Unfortunately, the preference setting code was generated by some faulty regex.

Discrepancy spotted after "10-Way" article published, unfortunately. Hopefully, revised numbers will be more representative of the high end.