### PR TITLE
Fix nc hanging by adding idle timeout

### DIFF
--- a/pts/network-loopback-1.0.1/install.sh
+++ b/pts/network-loopback-1.0.1/install.sh
@@ -4,6 +4,6 @@ echo "#!/bin/sh
 
 nc -d -l 9999 > /dev/null &
 sleep 3
-dd if=/dev/zero bs=1M count=10000 | nc localhost 9999
+dd if=/dev/zero bs=1M count=10000 | nc -w 3 localhost 9999
 echo \$? > ~/test-exit-status" > network-loopback
 chmod +x network-loopback


### PR DESCRIPTION
nc was hanging up in my tests, so I read the man page for it and added the -w 3 for it to timeout after 3 seconds of inactivity, and it worked.