### PR TITLE
pts/java-gradle-perf-1.0.0 Initial commit

### DIFF
--- a/pts/java-gradle-perf-1.0.0/downloads.xml
+++ b/pts/java-gradle-perf-1.0.0/downloads.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.0m0-->
+<PhoronixTestSuite>
+  <Downloads>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/java-gradle-perf-1.0.0/install.sh
+++ b/pts/java-gradle-perf-1.0.0/install.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+
+# Only get the tag we want
+git clone --depth 1 git@github.com:reactor/reactor-core.git
+cd reactor-core
+git fetch origin v2.5.0.M1:tags/v2.5.0.M1
+git checkout v2.5.0.M1
+
+# build once to get all dependencies
+./gradlew build
+cd ..
+
+echo "#!/bin/sh
+cd reactor-core
+# Building offline to get consistent timing
+./gradlew --offline clean build > \$LOG_FILE
+echo \$? > ~/test-exit-status" > java-gradle-perf
+chmod +x java-gradle-perf

--- a/pts/java-gradle-perf-1.0.0/results-definition.xml
+++ b/pts/java-gradle-perf-1.0.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.0m0-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Total time: #TEST_REACTOR# secs</OutputTemplate>
+    <ResultKey>PTS_TEST_ARGUMENTS</ResultKey>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/java-gradle-perf-1.0.0/test-definition.xml
+++ b/pts/java-gradle-perf-1.0.0/test-definition.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.0m0-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Java Build Stuff</Title>
+    <AppVersion>1.0</AppVersion>
+    <Description>This test runs Java software project builds using the Gradle build system.  It is intended to give developers an idea as to the build performance for development activities and build servers.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>4</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.0</Version>
+    <SupportedPlatforms>Linux, Solaris, BSD, MacOSX, Windows</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>java</ExternalDependencies>
+    <EnvironmentSize>200</EnvironmentSize>
+    <ProjectURL>http://xx/</ProjectURL>
+    <InternalTags>Java</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <AllowCacheShare>TRUE</AllowCacheShare>
+    </Default>
+    <Option>
+      <DisplayName>Gradle Build</DisplayName>
+      <Identifier>gradle-build</Identifier>
+      <ArgumentPrefix>TEST_</ArgumentPrefix>
+      <ArgumentPostfix></ArgumentPostfix>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>Reactor</Name>
+          <Value>REACTOR</Value>
+          <Message></Message>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
As a Java developer, I'd like to see comparisons of build performance for Java projects.

Naturally this is a blend of the CPU's efficiency in running the Java virtual machine, memory bandwidth, and disk performance.

For a representative project, I've picked a project with a good number of tests but hopefully not too many dependencies (it still requires just under 200Mb for the git clone and deps in ~/.gradle).

On my i7 3520M it takes 30 seconds to build, most of which is single threaded but at times using multiple threads.

What I haven't specified is a specific version of Java.  I have Java 8 locally installed.  I suspect something will need to change on this PR to add in an appropriate dependency to ensure Java is installed.

Perhaps that is something that might be a parameter such that it could also be used as a test for comparing different Java versions.