### PR TITLE
Add a test profile for Rise Of The Tomb Raider on Linux

### DIFF
--- a/pts/riseofthetombraider-1.0.0/install.sh
+++ b/pts/riseofthetombraider-1.0.0/install.sh
@@ -1,0 +1,155 @@
+#!/bin/bash -e
+# Install Rise of the Tomb Raider on Linux and generate launcher scripts and preference templates
+
+# Base constants
+#
+export HOME="$DEBUG_REAL_HOME"
+export STEAM_GAME_ID=391220
+export GAME_PREFS="$DEBUG_REAL_HOME/.local/share/feral-interactive/Rise of the Tomb Raider"
+export GAME_INSTALL_DIR_BASE="steamapps/common/Rise of the Tomb Raider/"
+export DEFAULT_STEAM_INSTALL_BASE="$HOME/.steam/steam"
+
+
+# Try and install the game in case it isn't already
+#
+HOME="$DEBUG_REAL_HOME" steam "steam://install/$STEAM_GAME_ID"
+
+
+# Work out the steam install directory
+#
+export CONFIG_PATH="$HOME/.steam/steam/config/config.vdf"
+_INSTALL_PATHS=$( awk '/BaseInstallFolder/ { gsub(/"/, "", $2); print $2 }' "${CONFIG_PATH}" )
+
+# Find one that contains the game
+while read -r STEAM_PATH; do
+	_NEW_FULL_PATH="${STEAM_PATH}/${GAME_INSTALL_DIR_BASE}"
+	if [ -d "${_NEW_FULL_PATH}" ]; then
+		export GAME_INSTALL_DIR="${_NEW_FULL_PATH}"
+	fi
+done <<< "${_INSTALL_PATHS}"
+
+# Allow the default location as well
+if [ ! -d "${GAME_INSTALL_DIR}" ]; then
+	export GAME_INSTALL_DIR="${DEFAULT_STEAM_INSTALL_BASE}/${GAME_INSTALL_DIR_BASE}"
+fi
+
+# Bail if we still couldn't find the game
+if [ ! -f "${GAME_INSTALL_DIR}/RiseOfTheTombRaider.sh" ]; then
+	>&2 echo "Missing run script in install dir - ${GAME_INSTALL_DIR}/RiseOfTheTombRaider.sh"
+	exit 1
+fi
+
+
+# Gather the steam env variables the game runs with
+#
+steam steam://run/$STEAM_GAME_ID &
+sleep 6
+GAME_PID=$( pgrep RiseOfTheTomb | tail -1 )
+echo '#!/bin/sh' > steam-env-vars.sh
+echo "# Collected steam environment for Rise of the Tomb Raider\n# PID : $GAME_PID" >> steam-env-vars.sh
+awk -v 'RS=\0' -F= '{ printf "export %s=\"%s\"\n", $1, $2 }' "/proc/$GAME_PID/environ" >> steam-env-vars.sh
+killall -9 RiseOfTheTombRaider
+sleep 6
+
+
+# Create the game launching script
+#
+cat > riseofthetombraider <<- EOM
+#!/bin/bash
+# Generated run script for Rise of the Tomb Raider
+# $( date )
+
+# Source the steam runtime environment
+#
+. steam-env-vars.sh
+
+# Run the game
+#
+cd "${GAME_INSTALL_DIR}"
+./RiseOfTheTombRaider.sh
+
+# Grab the output (most recent xml file results line)
+#
+# NOTE: There's also a location_machine_frametimes_datetime.txt file for more detailed results
+RESULTS_DIR="${GAME_PREFS}/VFS/User/AppData/Roaming/Rise of the Tomb Raider/"
+mkdir -p "\${RESULTS_DIR}"
+cd "\${RESULTS_DIR}"
+BENCH_NAMES="SpineOfTheMountain ProphetsTomb GeothermalValley"
+true > "\$LOG_FILE"
+for BENCH in \$BENCH_NAMES
+do
+	FPS_VALUES=\$( grep --text --no-filename FPS \${BENCH}_*.txt | head -3 | tr -d '\\r' | paste -s )
+	echo "\${BENCH}: \${FPS_VALUES}" >> "\$LOG_FILE"
+done
+EOM
+chmod +x riseofthetombraider
+
+
+# Create the template preferences file
+#
+cat > preferences.template.xml <<- EOM
+<?xml version="1.0" encoding="UTF-8"?>
+<registry>
+    <key name="HKEY_CLASSES_ROOT">
+    </key>
+    <key name="HKEY_CURRENT_CONFIG">
+    </key>
+    <key name="HKEY_CURRENT_USER">
+        <key name="Software">
+            <key name="Feral Interactive">
+                <key name="Rise of the Tomb Raider">
+                    <key name="Setup">
+                        <!-- screen resolutions -->
+                        <value name="ScreenH" type="integer">@ScreenH@</value>
+                        <value name="ScreenW" type="integer">@ScreenW@</value>
+
+                        <value name="FullScreen" type="integer">1</value>
+
+                        <value name="QuitAfterBenchmark" type="integer">1</value>
+
+                        <!-- disable all forms of pausing -->
+                        <value name="PauseMoviesOnPause" type="integer">0</value>
+                        <value name="PauseOnSuspend" type="integer">0</value>
+                        <value name="PauseSoundOnPause" type="integer">0</value>
+                        <value name="PauseTimersOnPause" type="integer">0</value>
+                        <value name="AllowPausing" type="integer">0</value>
+
+                        <!-- don't send data without consent -->
+                        <value name="AllowSendUsageData" type="integer">0</value>
+
+                        <!-- stop the game options dialogue showing -->
+                        <value name="GameOptionsDialogShouldShow" type="integer">0</value>
+                        <value name="GameOptionsDialogShouldShowBigPicture" type="integer">0</value>
+                        <value name="GameOptionsDialogShown" type="integer">1</value>
+
+                        <!-- stop any potential warnings -->
+                        <value name="SoftwareUpdatedAskedUser" type="integer">1</value>
+                        <value name="SoftwareUpdatedCanCheck" type="integer">0</value>
+                        <value name="SkipDriverWarnings" type="integer">1</value>
+                        <value name="SkipOSWarnings" type="integer">1</value>
+                        <key name="SpecificationAlerts">
+                            <!-- NOTE: Un-comment this if comparing the effects of the CPU governor -->
+                            <!-- <value name="LnxCPUGovernorSubOptimal" type="integer">1</value> -->
+                        </key>
+
+                        <!-- Default Graphics Settings -->
+                        <value name="SkipDefaultSettings" type="integer">1</value>
+                        <value name="ForceDefaultPreset"  type="integer">1</value>
+                        <value name="DefaultPreset"       type="string">@DefaultPreset@</value>
+                        <value name="DefaultAntialiasing" type="integer">@DefaultAntialiasing@</value>
+
+                        <!-- VSync off to avoid monitor refresh-rate changing results -->
+                        <value name="DefaultVSync"        type="integer">0</value>
+                    </key>
+                </key>
+            </key>
+            <key name="MacDoze">
+                <key name="Config">
+                    <value name="ExtraCommandLine" type="string">-benchmark</value>
+                    <value name="ExtraCommandLineEnabled" type="integer">1</value>
+                </key>
+            </key>
+        </key>
+    </key>
+</registry>
+EOM

--- a/pts/riseofthetombraider-1.0.0/interim.sh
+++ b/pts/riseofthetombraider-1.0.0/interim.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+GAME_PREFS="$DEBUG_REAL_HOME/.local/share/feral-interactive/Rise of the Tomb Raider"
+
+# Clean out the game temp files to ensure we have a clean run
+rm -rf "${GAME_PREFS:?}/VFS"
+

--- a/pts/riseofthetombraider-1.0.0/post.sh
+++ b/pts/riseofthetombraider-1.0.0/post.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+GAME_PREFS="$DEBUG_REAL_HOME/.local/share/feral-interactive/Rise of the Tomb Raider"
+
+# Grab the old prefs bkp location
+DATETIME=$( cat /tmp/rotr-bkp-dt )
+rm /tmp/rotr-bkp-dt
+GAME_PREFS_BKP="${GAME_PREFS}.pts-$DATETIME-bkp"
+
+# Put back our game prefs
+rm -rf "${GAME_PREFS:?}/"
+mv "$GAME_PREFS_BKP" "$GAME_PREFS"

--- a/pts/riseofthetombraider-1.0.0/pre.sh
+++ b/pts/riseofthetombraider-1.0.0/pre.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+set -o xtrace
+exec > /tmp/test
+exec 2>&1
+
+# Input settings
+WIDTH=$1
+HEIGHT=$2
+SETTING=$3
+AA=$4
+
+# Game preferences
+export HOME=$DEBUG_REAL_HOME
+GAME_PREFS="$DEBUG_REAL_HOME/.local/share/feral-interactive/Rise of the Tomb Raider"
+
+# Set up (and back up) the game preferences files
+DATETIME=$( date +%Y-%d-%m-%H-%M )
+echo "$DATETIME" >/tmp/rotr-bkp-dt
+GAME_PREFS_BKP="${GAME_PREFS}.pts-$DATETIME-bkp"
+cp -r "$GAME_PREFS" "$GAME_PREFS_BKP"
+
+# clear previous runs
+rm -rf "${GAME_PREFS:?}"
+mkdir -p "${GAME_PREFS}"
+
+# Set up the files to use
+cp "preferences.template.xml" "$GAME_PREFS/preferences"
+
+# Replace the resolutions
+cd "$GAME_PREFS" || exit
+
+# Replace settings with those chosen
+sed -i "s/@ScreenW@/$WIDTH/g"          preferences
+sed -i "s/@ScreenH@/$HEIGHT/g"         preferences
+sed -i "s/@DefaultAntialiasing@/$AA/g" preferences
+sed -i "s/@DefaultPreset@/$SETTING/g"   preferences

--- a/pts/riseofthetombraider-1.0.0/results-definition.xml
+++ b/pts/riseofthetombraider-1.0.0/results-definition.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.4.0-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>SpineOfTheMountain: 		Min FPS: #_MIN_RESULT_#			Max FPS: #_MAX_RESULT_#			Average FPS: #_RESULT_#</OutputTemplate>
+    <LineHint>SpineOfTheMountain</LineHint>
+    <AppendToArgumentsDescription>Scene: Spine Of The Mountain</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>ProphetsTomb: 		Min FPS: #_MIN_RESULT_#			Max FPS: #_MAX_RESULT_#			Average FPS: #_RESULT_#</OutputTemplate>
+    <LineHint>ProphetsTomb</LineHint>
+    <AppendToArgumentsDescription>Scene: Prophets Tomb</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>GeothermalValley: 		Min FPS: #_MIN_RESULT_#			Max FPS: #_MAX_RESULT_#			Average FPS: #_RESULT_#</OutputTemplate>
+    <LineHint>GeothermalValley</LineHint>
+    <AppendToArgumentsDescription>Scene: Geothermal Valley</AppendToArgumentsDescription>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/riseofthetombraider-1.0.0/test-definition.xml
+++ b/pts/riseofthetombraider-1.0.0/test-definition.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.4.0-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Rise of the Tomb Raider</Title>
+    <Description>Rise of the Tomb Raider on Steam.
+
+The test profile assumes you have a Steam account, have Steam installed for the system, and that you own a copy of this game. This automates the process of executing the game and using its built-in benchmark mode.
+
+Backs up old preferences (in ~/.local/share/feral-interactive/) for the run.
+
+NOTES for cross-platform comparisons:
+    Due to the extreme demands of "Very High" 4K Texture Detail on all platforms, which can need ~6GB+ of VRAM, the "Very High" graphics preset on Linux only sets Texture Detail to "High".
+    Nvidia ambient occlusion modes are not featured on the Linux version (HBAO+ and VXAO).
+
+See notes in install.sh for a few small tweaks including disabling the CPU governor check when testing for it's effects
+    </Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>2</TimesToRun>
+    <PreInstallMessage>This test will attempt to install the necessary game using your Steam account. If the test appears hung you may need to manually exit the Steam client.</PreInstallMessage>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Game</SoftwareType>
+    <TestType>Graphics</TestType>
+    <License>Retail</License>
+    <Status>Verified</Status>
+    <SupportedArchitectures>x86_64</SupportedArchitectures>
+    <EnvironmentSize>2</EnvironmentSize>
+    <EstimatedTimePerRun>120</EstimatedTimePerRun>
+    <ProjectURL>https://store.steampowered.com/app/391220/</ProjectURL>
+    <Maintainer>Feral Interactive</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Resolution</DisplayName>
+      <Identifier>auto-resolution</Identifier>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>$VIDEO_WIDTH x $VIDEO_HEIGHT</Name>
+          <Value>$VIDEO_WIDTH $VIDEO_HEIGHT</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Graphics Preset</DisplayName>
+      <Identifier>graphics-preset</Identifier>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>Lowest</Name>
+          <Value>Lowest</Value>
+        </Entry>
+        <Entry>
+          <Name>Low</Name>
+          <Value>Low</Value>
+        </Entry>
+        <Entry>
+          <Name>Medium</Name>
+          <Value>Medium</Value>
+        </Entry>
+        <Entry>
+          <Name>High</Name>
+          <Value>High</Value>
+        </Entry>
+        <Entry>
+          <Name>Very High</Name>
+          <Value>VeryHigh</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Anti Aliasing</DisplayName>
+      <Identifier>anti-aliasing</Identifier>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>Off</Name>
+          <Value>0</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>FXAA</Name>
+          <Value>1</Value>
+          <Message>Fast Approximate AA</Message>
+        </Entry>
+        <Entry>
+          <Name>SMAA</Name>
+          <Value>2</Value>
+          <Message>Subpixel Morphological AA</Message>
+        </Entry>
+        <Entry>
+          <Name>SSAA 2x</Name>
+          <Value>3</Value>
+          <Message>Supersample AA 2x</Message>
+        </Entry>
+        <Entry>
+          <Name>SSAA 4x</Name>
+          <Value>4</Value>
+          <Message>Supersample AA 4x</Message>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
More details are listed in the test description.

Enhancements over previous pts tests for feral targets:
	* Automatic detection of Steam install directory
	* Cleaned up environment fetching (works with multiline env)
	* Uses simplified baseline preferences file
	* Handles backed up preferences properly

Known minor issues:
	* Something about the environment when running from the pts breaks dbus, so GameMode requests fail
	* Due to the split benchmark stats, final results can be hard to parse when viewing the HTML page