### PR TITLE
pts/glibc-bench: enable sin/cos glibc benchmarks

### DIFF
--- a/pts/glibc-bench-1.5.0/test-definition.xml
+++ b/pts/glibc-bench-1.5.0/test-definition.xml
@@ -60,6 +60,16 @@
           <Value>bench-sqrt</Value>
           <Message></Message>
         </Entry>
+        <Entry>
+          <Name>sin</Name>
+          <Value>bench-sin</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>cos</Name>
+          <Value>bench-cos</Value>
+          <Message></Message>
+        </Entry>
       </Menu>
     </Option>
   </TestSettings>


### PR DESCRIPTION
Signed-off-by: Leonardo Sandoval <leonardo.sandoval.gonzalez@linux.intel.com>