### PR TITLE
Cuda mini nbody 1.1.0

### DIFF
--- a/pts/cuda-mini-nbody-1.1.0/downloads.xml
+++ b/pts/cuda-mini-nbody-1.1.0/downloads.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v6.4.0-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://www.phoronix-test-suite.com/benchmark-files/mini-nbody-20151110.zip</URL>
+      <MD5>42b183b885ad9845a944124a0b331010</MD5>
+      <SHA256>a4ecd7be292ca1f0ec5b443deba1892424d05a8e9b20a6210f96a115043d00cc</SHA256>
+      <FileSize>20808</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/cuda-mini-nbody-1.1.0/install.sh
+++ b/pts/cuda-mini-nbody-1.1.0/install.sh
@@ -3,9 +3,6 @@
 unzip -o mini-nbody-20151110.zip
 cd mini-nbody-master/cuda
 
-#cc -std=c99 -O3 -fopenmp -DSHMOO -o test-nbody nbody-orig.cu -lm
-#echo $? > ~/install-exit-status
-
 cd ~/
 echo "#!/bin/sh
 

--- a/pts/cuda-mini-nbody-1.1.0/install.sh
+++ b/pts/cuda-mini-nbody-1.1.0/install.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+unzip -o mini-nbody-20151110.zip
+cd mini-nbody-master/cuda
+
+#cc -std=c99 -O3 -fopenmp -DSHMOO -o test-nbody nbody-orig.cu -lm
+#echo $? > ~/install-exit-status
+
+cd ~/
+echo "#!/bin/sh
+
+if [ -d /usr/local/cuda ]
+then
+	PATH=\"/usr/local/cuda/bin:\$PATH\"
+	LD_LIBRARY_PATH=/usr/local/cuda/lib64:\$LD_LIBRARY_PATH
+fi
+
+cd mini-nbody-master/cuda
+bash \$@ > \$LOG_FILE
+echo \$? > ~/test-exit-status" > cuda-mini-nbody
+chmod +x cuda-mini-nbody

--- a/pts/cuda-mini-nbody-1.1.0/results-definition.xml
+++ b/pts/cuda-mini-nbody-1.1.0/results-definition.xml
@@ -5,7 +5,7 @@
     <OutputTemplate>524288, #_RESULT_# </OutputTemplate>
     <LineHint>524288,</LineHint>
     <ResultScale>(NBody^2)/s</ResultScale>
-    <ResultProportion>LIB</ResultProportion>
+    <ResultProportion>MIB</ResultProportion>
   </ResultsParser>
 </PhoronixTestSuite>
 

--- a/pts/cuda-mini-nbody-1.1.0/results-definition.xml
+++ b/pts/cuda-mini-nbody-1.1.0/results-definition.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v6.4.0-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>524288, #_RESULT_# </OutputTemplate>
+    <LineHint>524288,</LineHint>
+    <ResultScale>(NBody^2)/s</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+</PhoronixTestSuite>
+

--- a/pts/cuda-mini-nbody-1.1.0/test-definition.xml
+++ b/pts/cuda-mini-nbody-1.1.0/test-definition.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v6.4.0-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>CUDA Mini-Nbody</Title>
+    <AppVersion>2015-11-10</AppVersion>
+    <Description>The CUDA version of Harrism's mini-nbody tests.</Description>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>Graphics</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, cuda</ExternalDependencies>
+    <EnvironmentSize>1</EnvironmentSize>
+    <ProjectURL>https://github.com/harrism/mini-nbody</ProjectURL>
+    <InternalTags>CUDA</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Test</DisplayName>
+      <Identifier>test</Identifier>
+      <ArgumentPrefix></ArgumentPrefix>
+      <ArgumentPostfix></ArgumentPostfix>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>Original</Name>
+          <Value>shmoo-cuda-nbody-orig.sh</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>SOA Data Layout</Name>
+          <Value>shmoo-cuda-nbody-soa.sh</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>Flush Denormals To Zero</Name>
+          <Value>shmoo-cuda-nbody-ftz.sh</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>Cache Blocking</Name>
+          <Value>shmoo-cuda-nbody-block.sh</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>Loop Unrolling</Name>
+          <Value>shmoo-cuda-nbody-unroll.sh</Value>
+          <Message></Message>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
References #21 

### DISCLAIMER:
The following change is the easiest to implement as it does not require to change the source files. This comes at the cost of readability, as results will be reported in the form:
```
phoronix-test-suite run pts/cuda-mini-nbody-1.1.0
[...]
    Average: 480.56 (NBody^2)/s
    Deviation: 0.57%
```
Where actually, to obtain the **iterations per second** metric, we would have to perform some math:
```
RESULT = 480.56 (NBody^2)/s
ACTUAL = (524288 * 524288) / ($RESULT) * 1e-9
       = 0.57199 seconds per iteration
```

Wait, but wasn't the seconds per iteration hidden behind an `#ifndef`?

Yes, though if we look at the source more carefully, the macro is defined from within each of the shell files invoked inside`.phoronix-test-suite/installed-tests/pts/cuda-mini-nbody-1.1.0/mini-nbody-master/cuda/`:
```
#### shmoo-cuda-nbody-orig.sh ####
SRC=nbody-orig.cu
EXE=nbody-orig

nvcc -arch=sm_35 -I../ -DSHMOO -o $EXE $SRC

echo $EXE
[...]
```

So **SHMOO** is set in here, we would have to modify the test source to change that. Also, removing it isn't really enough, as the test sources themselves look like this:
```
#### nbody-orig.cu ####
#ifndef SHMOO
    printf("Iteration %d: %.3f seconds\n", iter, tElapsed);
#endif
  }
  double avgTime = totalTime / (double)(nIters-1);

#ifdef SHMOO
  printf("%d, %0.3f\n", nBodies, 1e-9 * nBodies * nBodies / avgTime);
#else
  printf("Average rate for iterations 2 through %d: %.3f +- %.3f steps per second.\n",
         nIters, rate);
  printf("%d Bodies: average %0.3f Billion Interactions / second\n", nBodies, 1e-9 * nBodies * nBodies / avgTime);
#endif
```

And simply removing the `-DSHMOO` will cause the second block to run, which will throw the following error:
```
1 error detected in the compilation of "/tmp/tmpxft_0000a24b_00000000-8_nbody-orig.cpp1.ii".
```

### WHY DID I USE THE 524288 NBODY RESULT?
While testing I was profiling the core utilisation, the only time it peaked close to 100% (on both a Titan XP and Tesla V100) was during the last few tests.
I was running the following command:
```
nvidia-smi --query-gpu=timestamp,name,temperature.gpu,utilization.gpu,utilization.memory,memory.total,memory.free,memory.used --format=csv -l 2 -i 0
```
When Idle:
```
2018/06/13 15:52:56.630, Tesla V100, 36, 0 %, 0 %, 15360 MiB, 15358 MiB, 2 MiB

```
When running the first few tests:
```
2018/06/13 15:54:42.651, Tesla V100, 43, 0 %, 0 %, 15360 MiB, 15358 MiB, 2 MiB
2018/06/13 15:54:44.738, Tesla V100, 43, 0 %, 0 %, 15360 MiB, 15355 MiB, 5 MiB
2018/06/13 15:54:46.922, Tesla V100, 43, 0 %, 0 %, 15360 MiB, 15355 MiB, 5 MiB
```
When running the final two tests:
```
2018/06/13 15:54:46.922, Tesla V100, 43, 0 %, 0 %, 15360 MiB, 15355 MiB, 5 MiB
2018/06/13 15:54:48.982, Tesla V100, 43, 0 %, 0 %, 15360 MiB, 15334 MiB, 26 MiB
2018/06/13 15:54:51.180, Tesla V100, 43, 0 %, 0 %, 15360 MiB, 15355 MiB, 5 MiB
2018/06/13 15:54:53.246, Tesla V100, 50, 97 %, 0 %, 15360 MiB, 14947 MiB, 413 MiB
2018/06/13 15:54:55.264, Tesla V100, 44, 0 %, 0 %, 15360 MiB, 15336 MiB, 24 MiB
2018/06/13 15:54:57.308, Tesla V100, 54, 95 %, 0 %, 15360 MiB, 14924 MiB, 436 MiB
2018/06/13 15:54:59.309, Tesla V100, 54, 100 %, 0 %, 15360 MiB, 14924 MiB, 436 MiB
```
^ We can see GPU utilisation peak at 100% and memory go up to 400 MBs.

- - -
Hence this fix will give a metric which can be easily compared in a LIB fashion for different GPUs, even though it is only after the arithmetic operations described above that it becomes human readable.
By changing the test source for all the supplied tests, the actual Iterations per second metric could be used, and it would also no longer require 3 distinct test runs, as a single test run has 10 iterations already.
