### PR TITLE
Update primesieve test profile

### DIFF
--- a/pts/primesieve-1.5.0/downloads.xml
+++ b/pts/primesieve-1.5.0/downloads.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.0m0-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://dl.bintray.com/kimwalisch/primesieve/primesieve-7.1.tar.gz, http://www.phoronix-test-suite.com/benchmark-files/primesieve-7.1.tar.gz</URL>
+      <MD5>d0f8efe7da8032859c72af32a7b7694a</MD5>
+      <SHA256>b7922443fa0e5be08adc2e67e141886466c98a1706bf4e9175b1ef114aeb432b</SHA256>
+      <FileSize>158812</FileSize>
+    </Package>
+    <Package>
+      <URL>http://dl.bintray.com/kimwalisch/primesieve/primesieve-7.1-win64-console.zip</URL>
+      <MD5>48ecd84da63795bffeb893b08a23c949</MD5>
+      <SHA256>dd463572543a08086c5ab07d9643399033e6a8cebb30fdde0e5de3a66bbb4c09</SHA256>
+      <FileSize>298609</FileSize>
+      <PlatformSpecific>Windows</PlatformSpecific>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/primesieve-1.5.0/install.sh
+++ b/pts/primesieve-1.5.0/install.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+version=7.1
+tar xvf primesieve-$version.tar.gz
+cd primesieve-$version
+
+cmake . -DBUILD_SHARED_LIBS=OFF
+make -j $NUM_CPU_JOBS
+echo $? > ~/install-exit-status
+cd ..
+
+echo "#!/bin/sh
+primesieve-$version/./primesieve \$@ > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status" > primesieve-test
+chmod +x primesieve-test

--- a/pts/primesieve-1.5.0/install_windows.sh
+++ b/pts/primesieve-1.5.0/install_windows.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+unzip -o primesieve-7.1-win64-console.zip
+
+echo "#!/bin/sh
+./primesieve.exe \$@ > \$LOG_FILE" > primesieve-test
+chmod +x primesieve-test

--- a/pts/primesieve-1.5.0/results-definition.xml
+++ b/pts/primesieve-1.5.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.0m0-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Seconds: #_RESULT_#
+Primes: 37607912018</OutputTemplate>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/primesieve-1.5.0/test-definition.xml
+++ b/pts/primesieve-1.5.0/test-definition.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.0m0-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Primesieve</Title>
+    <AppVersion>7.1</AppVersion>
+    <Description>Primesieve generates prime numbers using a highly optimized sieve of Eratosthenes implementation. Primesieve benchmarks the CPU's L1/L2 cache performance.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <SubTitle>1e12 Prime Number Generation</SubTitle>
+    <Executable>primesieve-test</Executable>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.5.0</Version>
+    <SupportedPlatforms>Linux, BSD, Solaris, MacOSX, Windows</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, cmake</ExternalDependencies>
+    <EnvironmentSize>2.3</EnvironmentSize>
+    <ProjectURL>https://primesieve.org</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Kim Walisch</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments>1e12 --quiet --time</Arguments>
+    </Default>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
Hi Micheal,

I have updated the primesieve pts test profile to the latest primesieve-7.1 version (previously primesieve-6.2). I have increased the version to 1.5.0 (from 1.4.1) since the new primesieve test profile corresponds to a new primesieve major version.

primesieve-7.1 runs significantly faster on Intel Skylake-X and Xeon Skylake CPUs. Also the primesieve Windows binary is now built using clang-cl which improves performance and hopefully also scalability (or at least primesieve cannot be blamed for poor Windows scaling).

Greetings,
Kim