### PR TITLE
Add build-linux-kernel v1.9.0.

### DIFF
--- a/pts/build-linux-kernel-1.9.0/downloads.xml
+++ b/pts/build-linux-kernel-1.9.0/downloads.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://www.kernel.org/pub/linux/kernel/v4.x/linux-4.17.tar.gz, http://mirrors.mit.edu/kernel/linux/kernel/v4.x/linux-4.17.tar.gz</URL>
+      <MD5>d38f9a20ce591ecfb58e305a91148a91</MD5>
+      <SHA256>482e5141e63fb6413fc90a9c46dcc408b9b44011fca609c4988cb904143e93b5</SHA256>
+      <FileSize>157716315</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/build-linux-kernel-1.9.0/install.sh
+++ b/pts/build-linux-kernel-1.9.0/install.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "#!/bin/sh
+
+cd linux-4.17/
+make -s -j \$NUM_CPU_JOBS 2>&1
+echo \$? > ~/test-exit-status" > time-compile-kernel
+
+chmod +x time-compile-kernel

--- a/pts/build-linux-kernel-1.9.0/interim.sh
+++ b/pts/build-linux-kernel-1.9.0/interim.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd linux-4.17/
+make clean

--- a/pts/build-linux-kernel-1.9.0/post.sh
+++ b/pts/build-linux-kernel-1.9.0/post.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -rf linux-4.17/

--- a/pts/build-linux-kernel-1.9.0/pre.sh
+++ b/pts/build-linux-kernel-1.9.0/pre.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+rm -rf linux-4.17/
+tar -xf linux-4.17.tar.gz
+
+cd linux-4.17/
+make defconfig
+make clean

--- a/pts/build-linux-kernel-1.9.0/results-definition.xml
+++ b/pts/build-linux-kernel-1.9.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.1-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/build-linux-kernel-1.9.0/test-definition.xml
+++ b/pts/build-linux-kernel-1.9.0/test-definition.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Timed Linux Kernel Compilation</Title>
+    <AppVersion>4.17</AppVersion>
+    <Description>This test times how long it takes to build the Linux kernel.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <SubTitle>Time To Compile</SubTitle>
+    <Executable>time-compile-kernel</Executable>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.9.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, bc</ExternalDependencies>
+    <ProjectURL>http://www.kernel.org/</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>


### PR DESCRIPTION
Bump the kernel version to 4.17. Using kernel 4.13 breaks on system with
gcc v8.x.

@michaellarabel, please take a look. If some other process should be used, please let me know.