### PR TITLE
Running system/fio and pts/fio on FreeBSD

### DIFF
--- a/pts/fio-1.11.2/install.sh
+++ b/pts/fio-1.11.2/install.sh
@@ -3,7 +3,12 @@
 tar -xzf fio-3.1.tar.gz
 cd fio-3.1/
 ./configure
-make -j $NUM_CPU_JOBS
+if [ "$OS_TYPE" = "BSD" ]
+then
+	gmake -j $NUM_CPU_JOBS
+else
+	make -j $NUM_CPU_JOBS
+fi
 echo $? > ~/install-exit-status
 cd ~
 
@@ -25,9 +30,14 @@ buffered=\$3
 startdelay=5
 ramp_time=5
 runtime=20
-time_based
-disk_util=0
-clat_percentiles=0
+time_based\" > test.fio
+
+if [ \"\${OPERATING_SYSTEM}\" != \"freebsd\" ]
+then
+	echo \"disk_util=0\" >> test.fio
+fi
+
+echo \"clat_percentiles=0
 disable_lat=1
 disable_clat=1
 disable_slat=1
@@ -37,7 +47,7 @@ filename=fiofile
 [test]
 name=test
 bs=\$5
-stonewall\" > test.fio
+stonewall\" >> test.fio
 
 ./fio test.fio 2>&1 > \$LOG_FILE" > fio-run
 chmod +x fio-run

--- a/pts/fio-1.11.2/test-definition.xml
+++ b/pts/fio-1.11.2/test-definition.xml
@@ -10,7 +10,7 @@
   </TestInformation>
   <TestProfile>
     <Version>1.11.2</Version>
-    <SupportedPlatforms>Linux, MacOSX, Windows</SupportedPlatforms>
+    <SupportedPlatforms>Linux, BSD, MacOSX, Windows</SupportedPlatforms>
     <SoftwareType>Benchmark</SoftwareType>
     <TestType>Disk</TestType>
     <License>Free</License>

--- a/system/fio-1.9.0/install.sh
+++ b/system/fio-1.9.0/install.sh
@@ -26,9 +26,13 @@ buffered=\$3
 startdelay=5
 ramp_time=5
 runtime=20
-time_based
-disk_util=0
-clat_percentiles=0
+time_based\" > test.fio
+
+if [ \"\${OPERATING_SYSTEM}\" != \"freebsd\" ]; then
+	echo \"disk_util=0\" >> test.fio
+fi
+
+echo \"clat_percentiles=0
 disable_lat=1
 disable_clat=1
 disable_slat=1
@@ -38,7 +42,7 @@ filename=fiofile
 [test]
 name=test
 bs=\$5
-stonewall\" > test.fio
+stonewall\" >> test.fio
 
 fio test.fio 2>&1 > \$LOG_FILE
 fio --version | cut -d \"-\" -f 2 > ~/pts-test-version 2>/dev/null " > fio-run

--- a/system/fio-1.9.0/results-definition.xml
+++ b/system/fio-1.9.0/results-definition.xml
@@ -1,28 +1,29 @@
 <?xml version="1.0"?>
-<!--Phoronix Test Suite v7.4.0m4-->
+<!--Phoronix Test Suite v8.0.0m2-->
 <PhoronixTestSuite>
   <ResultsParser>
-    <OutputTemplate>  read : io=3274.5MB, bw=#_RESULT_#, iops=11931, runt= 46109msec</OutputTemplate>
-    <LineHint>runt=</LineHint>
+    <OutputTemplate>   READ: bw=#_RESULT_# (861MB/s), 821MiB/s-821MiB/s (861MB/s-861MB/s), io=16.4GiB (17.3GB), run=20002-20002msec</OutputTemplate>
+    <LineHint>: bw=</LineHint>
     <ResultAfterString>bw</ResultAfterString>
-    <StripFromResult>KB/s,</StripFromResult>
+    <StripFromResult>KiB/s</StripFromResult>
     <DivideResultBy>1000</DivideResultBy>
     <ResultScale>MB/s</ResultScale>
     <ResultProportion>HIB</ResultProportion>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate>  read : io=3274.5MB, bw=#_RESULT_#, iops=11931, runt= 46109msec</OutputTemplate>
-    <LineHint>runt=</LineHint>
+    <OutputTemplate>   READ: bw=#_RESULT_# (861MB/s), 821MiB/s-821MiB/s (861MB/s-861MB/s), io=16.4GiB (17.3GB), run=20002-20002msec</OutputTemplate>
+    <LineHint>: bw=</LineHint>
     <ResultAfterString>bw</ResultAfterString>
-    <StripFromResult>MB/s,</StripFromResult>
+    <StripFromResult>MiB/s</StripFromResult>
     <ResultScale>MB/s</ResultScale>
     <ResultProportion>HIB</ResultProportion>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate>  read : io=3274.5MB, bw=72203KB/s, iops=#_RESULT_#, runt= 46109msec</OutputTemplate>
-    <LineHint>runt=</LineHint>
-    <ResultAfterString>iops</ResultAfterString>
-    <StripFromResult>,</StripFromResult>
+    <OutputTemplate>  write: IOPS=#_RESULT_# BW=891MiB/s (934MB/s)(17.5GiB/20006msec)</OutputTemplate>
+    <LineHint>IOPS=</LineHint>
+    <ResultAfterString>IOPS</ResultAfterString>
+    <StripFromResult>k,</StripFromResult>
+    <MultiplyResultBy>1000</MultiplyResultBy>
     <ResultScale>IOPS</ResultScale>
     <ResultProportion>HIB</ResultProportion>
   </ResultsParser>


### PR DESCRIPTION
The `disk_util` option type is `FIO_OPT_UNSUPPORTED` on FreeBSD,
then find_option() returns NULL and fio(1) doesn't run with the option `disk_util=0`.

http://git.kernel.dk/?p=fio.git;a=blob;f=options.c;h=98187def98fbe842e90ae6d4a85a9fb3f358fd10;hb=ee6ce26c029dbdb62184d2f011fdab61d3429d82#l4307
```
4307 #ifdef FIO_HAVE_DISK_UTIL
4308         {
4309                 .name   = "disk_util",
4310                 .lname  = "Disk utilization",
4311                 .type   = FIO_OPT_BOOL,
4312                 .off1   = offsetof(struct thread_options, do_disk_util),
4313                 .help   = "Log disk utilization statistics",
4314                 .def    = "1",
4315                 .category = FIO_OPT_C_STAT,
4316                 .group  = FIO_OPT_G_INVALID,
4317         },
4318 #else
4319         {
4320                 .name   = "disk_util",
4321                 .lname  = "Disk utilization",
4322                 .type   = FIO_OPT_UNSUPPORTED,
4323                 .help   = "Your platform does not support disk utilization",
4324         },
```

http://git.kernel.dk/?p=fio.git;a=blob;f=parse.c;h=a7d4516e47028b9373c7012bd8b56877c8f493cf;hb=ee6ce26c029dbdb62184d2f011fdab61d3429d82#l1028
```
1028 struct fio_option *find_option(struct fio_option *options, const char *opt)
1029 {
1030         struct fio_option *o;
1031 
1032         for (o = &options[0]; o->name; o++) {
1033                 if (!o_match(o, opt))
1034                         continue;
1035                 if (o->type == FIO_OPT_UNSUPPORTED) {
1036                         log_err("Option <%s>: %s\n", o->name, o->help);
1037                         continue;
1038                 }
1039 
1040                 return o;
1041         }
1042 
1043         return NULL;
1044 }
```
```
% fio ~/test.fio                                                                            
Bad option type 13                                                                            
Option <disk_util>: Your platform does not support disk utilization                           
Option <disk_util>: Your platform does not support disk utilization                           
Bad option <disk_util=0>                                                                      
fio: job global dropped
```