### PR TITLE
running smallpt without optimizations has wild results across cpu's

### DIFF
--- a/pts/smallpt-1.1.0/install.sh
+++ b/pts/smallpt-1.1.0/install.sh
@@ -5,9 +5,9 @@ tar -zxvf smallpt-1.tar.gz
 
 if [ $OS_TYPE = "BSD" ]
 then
-	export CXXFLAGS="$XXCFLAGS -Wno-narrowing -L/usr/local/lib"
+	export CXXFLAGS="$XXCFLAGS  -Wno-narrowing -L/usr/local/lib"
 fi
-c++ -fopenmp $CXXFLAGS smallpt.cpp -o smallpt-renderer
+c++ -fopenmp $CXXFLAGS -O3 smallpt.cpp -o smallpt-renderer
 echo $? > ~/install-exit-status
 
 echo "#!/bin/sh


### PR DESCRIPTION
example
```
$ c++ -fopenmp -Wno-narrowing -L/usr/local/lib -O3 smallpt.cpp -o smallpt-renderer
$ ./smallpt-renderer 8
Rendering (8 spp) 100.00%

Elapsed Time: 17.000000 Seconds

$ c++ -fopenmp -Wno-narrowing -L/usr/local/lib smallpt.cpp -o smallpt-renderer
smallpt.cpp:60:48: warning: add explicit braces to avoid dangling else [-Wdangling-else]
  if (++depth>5) if (erand48(Xi)<p) f=f*(1/p); else return obj.e; //R.R.
                                               ^
1 warning generated.
$./smallpt-renderer 8
Rendering (8 spp) 100.00%

Elapsed Time: 37.000000 Seconds
```

This is on a fairly old box running FreeBSD, however, these results were ran on CoreOS

Model | Description | Units | Results
-- | -- | -- | --
R730xd | Global Illumination Renderer; 128 Sampes Per Pixel | Seconds | 15.85
R740xd | Global Illumination Renderer; 128 Sampes Per Pixel | Seconds | 188.63
R7425 | Global Illumination Renderer; 128 Sampes Per Pixel | Seconds | 14.07

on new Dell PowerEdge hardware. 

The R740xd is a skylake processor, but adding -O3 eliminates this drastically different score