### PR TITLE
Fix aircrack-ng-1.1.1 for FreeBSD support

### DIFF
--- a/pts/aircrack-ng-1.1.1/install.sh
+++ b/pts/aircrack-ng-1.1.1/install.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 tar -xf aircrack-ng-1.3.tar.gz
 cd aircrack-ng-1.3
-./autogen.sh 
-make -j $NUM_CPU_CORES
+if [ "$OS_TYPE" = "BSD" ]
+then
+	if [ -e /usr/local/lib/libcrypto.so ]
+	then
+		env MAKE=gmake CFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib ./autogen.sh
+	else
+		env MAKE=gmake ./autogen.sh
+	fi
+	gmake -j $NUM_CPU_CORES
+else
+	./autogen.sh
+	make -j $NUM_CPU_CORES
+fi
 echo $? > ~/install-exit-status
 
 cd ~

--- a/pts/aircrack-ng-1.1.1/test-definition.xml
+++ b/pts/aircrack-ng-1.1.1/test-definition.xml
@@ -16,7 +16,7 @@
     <TestType>Processor</TestType>
     <License>Free</License>
     <Status>Verified</Status>
-    <ExternalDependencies>build-utilities, openssl-development, libtool, pkg-config</ExternalDependencies>
+    <ExternalDependencies>build-utilities, openssl-development, libtool</ExternalDependencies>
     <EnvironmentSize>25</EnvironmentSize>
     <ProjectURL>http://www.aircrack-ng.org/</ProjectURL>
     <Maintainer>Michael Larabel</Maintainer>

--- a/pts/aircrack-ng-1.1.1/test-definition.xml
+++ b/pts/aircrack-ng-1.1.1/test-definition.xml
@@ -16,7 +16,7 @@
     <TestType>Processor</TestType>
     <License>Free</License>
     <Status>Verified</Status>
-    <ExternalDependencies>build-utilities, openssl-development, libtool</ExternalDependencies>
+    <ExternalDependencies>build-utilities, openssl-development, libtool, pkg-config</ExternalDependencies>
     <EnvironmentSize>25</EnvironmentSize>
     <ProjectURL>http://www.aircrack-ng.org/</ProjectURL>
     <Maintainer>Michael Larabel</Maintainer>


### PR DESCRIPTION
pkg-config is required to compile aircrack-ng on FreeBSD,
these macros are defined in /usr/local/share/aclocal/pkg.m4
which belongs to the port devel/pkgconf.
```
configure.ac:62: error: possibly undefined macro1: AC_SUBST
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure:18742: error: possibly undefined macro1: AC_MSG_RESULT
configure:19713: error: possibly undefined macro1: AC_DEFINE
```
Also set the CFLAGS and LDFLAGS for the systems that have security/openssl port installed,
FreeBSD 12.0-RELEASE and 13.0-CURRENT have OpenSSL 1.1.1 in base and 1.0.2 in the port security/openssl.

Compiling on a system with two versions of OpenSSL in both base and ports
will result in errors like undefined symbol HMAC_CTX_new/HMAC_CTX_init, etc.