### PR TITLE
pts/dav1d-1.0.0: avoid writing to disk

### DIFF
--- a/pts/dav1d-1.0.0/install.sh
+++ b/pts/dav1d-1.0.0/install.sh
@@ -27,6 +27,6 @@ echo $? > ~/install-exit-status
 cd ~
 
 echo "#!/bin/sh
-./dav1d-0.1.0/build/tools/dav1d \$@ -o output.yuv --framethreads \$NUM_CPU_CORES --tilethreads 4
+./dav1d-0.1.0/build/tools/dav1d \$@ --muxer null --framethreads \$NUM_CPU_CORES --tilethreads 4
 echo \$? > ~/test-exit-status" > dav1d
 chmod +x dav1d


### PR DESCRIPTION
Current command line makes it IO-bound because RAW uncompressed video is
pretty huge (11GB in case of summer_nature_1080p.yuv). By using null muxer
instead we benchmarking only the actual decoding step.

Results for HDD:

```
$ time dav1d -i summer_nature_1080p.ivf -o output.yuv --framethreads 8 --tilethreads 4
dav1d 0.1.0-0-ga6b903f - by VideoLAN
Decoded 3604/3604 frames (100.0%)
245% cpu 2:09.87 total
```

```
$ time dav1d -i summer_nature_1080p.ivf --muxer null --framethreads 8 --tilethreads 4
dav1d 0.1.0-0-ga6b903f - by VideoLAN
Decoded 3604/3604 frames (100.0%)
482% cpu 1:04.67 total
```