### PR TITLE
Update config.guess for aarch64 platform

### DIFF
--- a/pts/compress-lzma-1.3.1/install.sh
+++ b/pts/compress-lzma-1.3.1/install.sh
@@ -4,6 +4,7 @@ mkdir $HOME/lzma_
 
 tar -zxvf lzma-4.32.7.tar.gz
 cd lzma-4.32.7
+wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -O config.guess
 ./configure --prefix=$HOME/lzma_
 make -j $NUM_CPU_JOBS
 echo $? > ~/install-exit-status

--- a/pts/encode-ogg-1.5.1/install.sh
+++ b/pts/encode-ogg-1.5.1/install.sh
@@ -11,6 +11,7 @@ tar -zxvf libvorbis-1.3.5.tar.gz
 tar -zxvf vorbis-tools-1.4.0.tar.gz
 
 cd libogg-1.3.3/
+wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -O config.guess
 ./configure --prefix=$HOME/vorbis
 make -j $NUM_CPU_JOBS
 make install
@@ -18,6 +19,7 @@ cd ..
 #rm -rf libogg-1.3.3/
 
 cd libvorbis-1.3.5/
+wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -O config.guess
 ./configure --prefix=$HOME/vorbis --with-ogg-includes=$HOME/vorbis/include/ogg --with-ogg-libraries=$HOME/vorbis/lib
 make -j $NUM_CPU_JOBS
 make install
@@ -25,6 +27,7 @@ cd ..
 #rm -rf libvorbis-1.3.5/
 
 cd vorbis-tools-1.4.0/
+wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -O config.guess
 ./configure --prefix=$HOME/vorbis --with-ogg-includes=$HOME/vorbis/include/ogg --with-ogg-libraries=$HOME/vorbis/lib --with-vorbis-includes=$HOME/vorbis/include/vorbis --with-vorbis-libraries=$HOME/vorbis/lib
 make -j $NUM_CPU_JOBS
 echo $? > ~/install-exit-status

--- a/pts/hmmer-1.1.0/install.sh
+++ b/pts/hmmer-1.1.0/install.sh
@@ -4,6 +4,7 @@ mkdir -p $HOME/hmmer_
 
 tar -zxvf hmmer-2.3.2.tar.gz
 cd hmmer-2.3.2/
+wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -O config.guess
 ./configure --enable-threads --prefix=$HOME/hmmer_
 make -j $NUM_CPU_JOBS
 echo $? > ~/install-exit-status

--- a/pts/hmmer-1.1.1/install.sh
+++ b/pts/hmmer-1.1.1/install.sh
@@ -4,6 +4,7 @@ mkdir -p $HOME/hmmer_
 
 tar -zxvf hmmer-2.3.2.tar.gz
 cd hmmer-2.3.2/
+wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -O config.guess
 ./configure --enable-threads --prefix=$HOME/hmmer_
 make -j $NUM_CPU_JOBS
 echo $? > ~/install-exit-status

--- a/pts/hmmer-1.1.2/install.sh
+++ b/pts/hmmer-1.1.2/install.sh
@@ -4,6 +4,7 @@ mkdir -p $HOME/hmmer_
 
 tar -zxvf hmmer-2.3.2.tar.gz
 cd hmmer-2.3.2/
+wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -O config.guess
 ./configure --enable-threads --prefix=$HOME/hmmer_
 make -j $NUM_CPU_JOBS
 echo $? > ~/install-exit-status

--- a/pts/nero2d
+++ b/pts/nero2d
@@ -1,0 +1,3 @@
+#!/bin/sh
+mpirun ./nero2d_/bin/nero2d $@ > $LOG_FILE 2>&1
+echo $? > ~/test-exit-status

--- a/pts/nero2d
+++ b/pts/nero2d
@@ -1,3 +1,0 @@
-#!/bin/sh
-mpirun ./nero2d_/bin/nero2d $@ > $LOG_FILE 2>&1
-echo $? > ~/test-exit-status

--- a/pts/nero2d-1.1.0/install.sh
+++ b/pts/nero2d-1.1.0/install.sh
@@ -4,6 +4,7 @@ mkdir $HOME/nero2d_
 
 tar -zxvf nero2d-2.0.2-pts1.tar.gz
 cd nero2d-2.0.2/
+wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -O config.guess
 ./configure --prefix=$HOME/nero2d_ --enable-mpi
 make -j $NUM_CPU_JOBS
 echo $? > ~/install-exit-status


### PR DESCRIPTION
Below tests are not working in aarch64 platform and facing error **configure: error: cannot guess build type; you must specify one** :
nero2d-1.1.0
compress-lzma-1.3.1
encode-ogg-1.5.1
hmmer-1.1.2

Updated install.sh for each profile to replace config.guess from location http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
