### PR TITLE
WIP: Update broken aom-av1 profile to 1.1.0 (help wanted)

### DIFF
--- a/pts/aom-av1-1.0.1/downloads.xml
+++ b/pts/aom-av1-1.0.1/downloads.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.6.0-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z</URL>
+      <MD5>84ae521c95aa2537e16b34bbf72f2def</MD5>
+      <SHA256>e2f60b904789a60f6d1edc194d8540d401dd882e3ee3605b9b1de8feacc72133</SHA256>
+      <FileSize>676792531</FileSize>
+    </Package>
+    <Package>
+      <URL>https://aomedia.googlesource.com/aom/+archive/add4b15580e410c00c927ee366fa65545045a5d9.tar.gz</URL>
+      <MD5>1D16604A8DA61CE28BA00C4177A3F0E9</MD5>
+      <SHA256>F134A21BE499F6BDF2D2C020E21598DEA6B05E2F17193CCFB7FA36B64ECA135E</SHA256>
+      <FileSize>2778573</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/aom-av1-1.0.1/install.sh
+++ b/pts/aom-av1-1.0.1/install.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+tar -xf aom-add4b15580e410c00c927ee366fa65545045a5d9.tar.gz
+cd aom/build
+cmake ..
+make -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+cd ~
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
+
+echo "#!/bin/sh
+./aom/build/aomenc -v --good --threads=\$NUM_CPU_CORES --tile-columns=2 --limit=3 --row-mt=1 -o test.av1 Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status" > aom-av1
+chmod +x aom-av1

--- a/pts/aom-av1-1.0.1/results-definition.xml
+++ b/pts/aom-av1-1.0.1/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.6.0m1-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/aom-av1-1.0.1/test-definition.xml
+++ b/pts/aom-av1-1.0.1/test-definition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.6.0-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>AOM AV1</Title>
+    <AppVersion>2019-01-08</AppVersion>
+    <Description>This is a simple test of the AOMedia AV1 encoder run on the CPU with a sample video file.</Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <SubTitle>AV1 Video Encoding</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.0</Version>
+    <SupportedPlatforms>Linux, MacOSX, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Broken</Status>
+    <ExternalDependencies>build-utilities, p7zip, cmake, perl, yasm</ExternalDependencies>
+    <EnvironmentSize>369</EnvironmentSize>
+    <ProjectURL>https://aomedia.googlesource.com/aom/</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>


### PR DESCRIPTION
This PR updates the aom-av1 test profile to a more recent and stable versions. It also enables row multi-threading (`--row-mt=1`) for higher performance on CPU's with high core counts.

The test profile is broken, however, so that needs to be fixed. Furthermore, I would propose to test the encoder with two speed settings and the encoder settings for aomenc should be reviewed.

Right now a huge 667 MB test file (.y4m video) is downloaded, while only 3 frames are being encoded. If only the first 3 frames are encoded, the test file could also be only 25 MB. I would propose downloading a 12 frame test file of around 100 MB, and then encoding 12 frames for `--cpu-used=4` and 4 frames for `--cpu-used=1`.

**Done so far:**
 - [x] Updated aom version [to](https://aomedia.googlesource.com/aom/+/v1.0.0-errata1) `v1.0.0-errata1`
 - [x] Added `--row-mt=1`  as encoder parameter

**To-do (and help wanted):**
 - [ ] Fix bug where aom-av1 test profile doesn's deliver test results
 - [ ] Add two test settings for different speed (`--cpu-used=1` and `--cpu-used=4` maybe?)
 - [ ] Review aomenc encoder parameters
 - [ ] Create and download a smaller .y4m video with only the frames needed
