### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/pts/netperf-1.0.2/install.sh
+++ b/pts/netperf-1.0.2/install.sh
@@ -10,6 +10,103 @@ else
           CFLAGS="$CFLAGS_OVERRIDE"
 fi
 
+if [ "$OS_TYPE" = "BSD" ]
+then
+# https://github.com/HewlettPackard/netperf/commit/328fe3b56a8753f6f700aac2b2df84dda5ce93a3.patch
+	cat > 328fe3b56a8753f6f700aac2b2df84dda5ce93a3.patch <<EOT
+From 328fe3b56a8753f6f700aac2b2df84dda5ce93a3 Mon Sep 17 00:00:00 2001
+From: raj <raj@5bbd99f3-5903-0410-b283-f1d88047b228>
+Date: Fri, 7 Aug 2015 15:49:52 +0000
+Subject: [PATCH] Some additional FreeBSD fixes from Andrew Gallatin.
+
+---
+ AUTHORS      | 3 ++-
+ configure    | 4 ++--
+ configure.ac | 4 ++--
+ src/dscp.c   | 3 +++
+ 4 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/AUTHORS b/AUTHORS
+index b1a17fd..4dae415 100644
+--- a/AUTHORS
++++ b/AUTHORS
+@@ -107,6 +107,7 @@ calibration-free
+ fixes to configure to recognize Solaris 11
+ fixes to netcpu_procstat.c for later linux kernels
+ workarounds to get Linux to report ENOBUFS on TX queue overflows
++FreeBSD fixes
+ 
+ Mark Cooper
+ pointing-out the need for -lresolv when compiling -DDO_DNS on RedHat
+@@ -306,4 +307,4 @@ the UDP socket connected at the netserver side.
+ 
+ Weijia Song - a fix inspiration for a NULL pointer problem.
+ 
+-Gisle Vanem - some Windows compilation fixes
+\ No newline at end of file
++Gisle Vanem - some Windows compilation fixes
+diff --git a/configure b/configure
+index 3935873..8fd2227 100755
+--- a/configure
++++ b/configure
+@@ -6567,7 +6567,7 @@ fi
+ done
+ 
+ 		case "$host" in
+-		*-*-freebsd78.*)
++		*-*-freebsd[7-9].* | *-*-freebsd1[0-1].* )
+ 			# FreeBSD 7.x and later SCTP support doesn't need -lsctp.
+ 			;;
+ 		*)
+@@ -7142,7 +7142,7 @@ ac_cv_lib_kstat=ac_cv_lib_kstat_main
+ 			enable_cpuutil="kstat - auto"
+ 			NETCPU_SOURCE="kstat"
+ 			;;
+-                     *-*-freebsd[4-8].* | *-*-netbsd[1-9].* )
++                     *-*-freebsd[4-9].* | *-*-freebsd1[0-1].* | *-*-netbsd[1-9].* )
+ 			use_cpuutil=true
+ 
+ $as_echo "#define USE_SYSCTL /**/" >>confdefs.h
+diff --git a/configure.ac b/configure.ac
+index 4c01090..caba026 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -467,7 +467,7 @@ case "$enable_sctp" in
+ #include <sys/socket.h>
+ ]])
+ 		case "$host" in
+-		*-*-freebsd[78].*)
++		*-*-freebsd[[7-9]].* | *-*-freebsd1[[0-1]].* )
+ 			# FreeBSD 7.x and later SCTP support doesn't need -lsctp.
+ 			;;
+ 		*)
+@@ -699,7 +699,7 @@ case "$enable_cpuutil" in
+ 			enable_cpuutil="kstat - auto"
+ 			NETCPU_SOURCE="kstat"
+ 			;;
+-                     *-*-freebsd[[4-8]].* | *-*-netbsd[[1-9]].* )
++                     *-*-freebsd[[4-9]].* | *-*-freebsd1[[0-1]].* | *-*-netbsd[[1-9]].* )
+ 			use_cpuutil=true
+ 			AC_DEFINE([USE_SYSCTL],,[Use MumbleBSD's sysctl interface to measure CPU util.])
+ 			enable_cpuutil="sysctl - auto"
+diff --git a/src/dscp.c b/src/dscp.c
+index 30fcdac..1b77624 100644
+--- a/src/dscp.c
++++ b/src/dscp.c
+@@ -54,6 +54,9 @@ const char * iptos2str(int iptos);
+  */
+ 
+ #if HAVE_NETINET_IN_SYSTM_H
++#if defined(__FreeBSD__)
++#include <sys/types.h>
++#endif
+ #include <netinet/in_systm.h>
+ #endif
+ #if HAVE_NETINET_IP_H
+EOT
+	patch -p1 < 328fe3b56a8753f6f700aac2b2df84dda5ce93a3.patch
+fi
+
 ./configure CFLAGS="$CFLAGS"
 make -j $NUM_CPU_CORES
 echo $? > ~/install-exit-status


### PR DESCRIPTION

`phoronix-test-suite install netperf` on FreeBSD 11.2-RELEASE
```
......
--- dscp.o ---
clang -DHAVE_CONFIG_H -I. -I..      -O3 -march=native -MT dscp.o -MD -MP -MF .deps/dscp.Tpo -c -o dscp.o dscp.c
--- net_uuid.o ---
net_uuid.c:158:5: warning: implicit declaration of function 'read' is invalid in C99 [-Wimplicit-function-declaration]
--- dscp.o ---
In file included from dscp.c:57:
/usr/include/netinet/in_systm.h:52:9: error: unknown type name 'u_int16_t'
typedef u_int16_t n_short;              /* short as received from the net */
        ^
/usr/include/netinet/in_systm.h:53:9: error: unknown type name 'u_int32_t'
typedef u_int32_t n_long;               /* long as received from the net */
        ^
/usr/include/netinet/in_systm.h:55:9: error: unknown type name 'u_int32_t'
typedef u_int32_t n_time;               /* ms since 00:00 UTC, byte rev */
        ^
3 errors generated.
*** [dscp.o] Error code 1

make[3]: stopped in /root/.phoronix-test-suite/installed-tests/pts/netperf-1.0.2/netperf-2.7.0/src
--- net_uuid.o ---
    read(fd, seed, 16);
    ^
net_uuid.c:159:5: warning: implicit declaration of function 'close' is invalid in C99 [-Wimplicit-function-declaration]
    close(fd);
    ^
2 warnings generated.
mv -f .deps/net_uuid.Tpo .deps/net_uuid.Po
--- nettest_omni.o ---
nettest_omni.c:3506:49: warning: passing 'int *' to parameter of type 'socklen_t *' (aka 'unsigned int *') converts between pointers to integer types with different sign [-Wpointer-sign]
                      protocol, TCP_CONGESTION, cong_control, &my_len) ==
                                                              ^~~~~~~
/usr/include/sys/socket.h:625:72: note: passing argument to parameter here
int     getsockopt(int, int, int, void * __restrict, socklen_t * __restrict);
                                                                           ^
nettest_omni.c:4004:8: warning: passing 'uint32_t *' (aka 'unsigned int *') to parameter of type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                          &(omni_request->netperf_port));
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./nettest_bsd.h:633:13: note: passing argument to parameter 'port' here
                                          int *port);
                                               ^
nettest_omni.c:4008:8: warning: passing 'uint32_t *' (aka 'unsigned int *') to parameter of type 'int *' converts between pointers to integer types with different sign [-Wpointer-sign]
                                          &(omni_request->data_port));
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~
./nettest_bsd.h:633:13: note: passing argument to parameter 'port' here
                                          int *port);
                                               ^
nettest_omni.c:4369:4: warning: passing 'int *' to parameter of type 'unsigned int *' converts between pointers to integer types with different sign [-Wpointer-sign]
                        &remote_addr_len,
                        ^~~~~~~~~~~~~~~~
nettest_omni.c:3137:127: note: passing argument to parameter 'sourcelen' here
recv_data(SOCKET data_socket, struct ring_elt *recv_ring, uint32_t bytes_to_recv, struct sockaddr *source, netperf_socklen_t *sourcelen, uint32_t flags, uint32_t *num_receives) {
                                                                                                                              ^
--- nettest_bsd.o ---
mv -f .deps/nettest_bsd.Tpo .deps/nettest_bsd.Po
--- nettest_omni.o ---
4 warnings generated.
mv -f .deps/nettest_omni.Tpo .deps/nettest_omni.Po
1 error

make[3]: stopped in /root/.phoronix-test-suite/installed-tests/pts/netperf-1.0.2/netperf-2.7.0/src
*** [all-recursive] Error code 1

make[2]: stopped in /root/.phoronix-test-suite/installed-tests/pts/netperf-1.0.2/netperf-2.7.0/src
1 error

make[2]: stopped in /root/.phoronix-test-suite/installed-tests/pts/netperf-1.0.2/netperf-2.7.0/src
*** [all-recursive] Error code 1

make[1]: stopped in /root/.phoronix-test-suite/installed-tests/pts/netperf-1.0.2/netperf-2.7.0
1 error

make[1]: stopped in /root/.phoronix-test-suite/installed-tests/pts/netperf-1.0.2/netperf-2.7.0
*** [all] Error code 2

make: stopped in /root/.phoronix-test-suite/installed-tests/pts/netperf-1.0.2/netperf-2.7.0
1 error

make: stopped in /root/.phoronix-test-suite/installed-tests/pts/netperf-1.0.2/netperf-2.7.0
```