### PR TITLE
Add profile for dav1d 0.3.0

### DIFF
--- a/pts/dav1d-1.2.0/downloads.xml
+++ b/pts/dav1d-1.2.0/downloads.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.6.0m1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://ffmpeg.org/releases/ffmpeg-4.1.3.tar.bz2</URL>
+      <MD5>9985185a8de3678e5b55b1c63276f8b5</MD5>
+      <SHA256>29a679685bd7bc29158110f367edf67b31b451f2176f9d79d0f342b9e22d6a2a</SHA256>
+      <FileName>ffmpeg-4.1.3.tar.bz2</FileName>
+      <FileSize>10424065</FileSize>
+    </Package>
+    <Package>
+      <URL>http://downloads.videolan.org/pub/videolan/dav1d/0.3.0/dav1d-0.3.0.tar.xz</URL>
+      <MD5>5102d3067eb8179d7c853d39a8c7a409</MD5>
+      <SHA256>7f229261595ed0940b5cb360d5f0045032ad5c9cbe0f7e71562ae6bee9bacf25</SHA256>
+      <FileName>dav1d-0.3.0.tar.xz</FileName>
+      <FileSize>381556</FileSize>
+    </Package>
+    <Package>
+      <URL>http://www.elecard.com/storage/video/Stream2_AV1_HD_6.8mbps.webm</URL>
+      <MD5>5e4c83cf494cbe6dc1668cbbd7ff774c</MD5>
+      <SHA256>2f23d29750a0663a6df656e8137cf934bddfc96b31e5088db2c3624f19ed14d4</SHA256>
+      <FileName>Stream2_AV1_HD_6.8mbps.webm</FileName>
+      <FileSize>122378926</FileSize>
+    </Package>
+    <Package>
+      <URL>http://www.elecard.com/storage/video/Stream2_AV1_4K_22.7mbps.webm</URL>
+      <MD5>8acc9c60c10a37bf4e568b465b03e35a</MD5>
+      <SHA256>52f3aa1d4b4487af62d37b0f295aabbc4b57f03fdc4c76402c6358193e4aa490</SHA256>
+      <FileName>Stream2_AV1_4K_22.7mbps.webm</FileName>
+      <FileSize>409458359</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/dav1d-1.2.0/install.sh
+++ b/pts/dav1d-1.2.0/install.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# FFmpeg install to demux AV1 WebM to IVF that can then be consumed by dav1d...
+tar -xjf ffmpeg-4.1.3.tar.bz2
+mkdir ffmpeg_/
+
+cd ffmpeg-4.1.3/
+./configure --disable-zlib --disable-doc --prefix=$HOME/ffmpeg_/
+make -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+make install
+cd ~/
+
+./ffmpeg_/bin/ffmpeg -i Stream2_AV1_HD_6.8mbps.webm -vcodec copy -an -f ivf summer_nature_1080p.ivf
+rm Stream2_AV1_HD_6.8mbps.webm
+./ffmpeg_/bin/ffmpeg -i Stream2_AV1_4K_22.7mbps.webm -vcodec copy -an -f ivf summer_nature_4k.ivf
+rm Stream2_AV1_4K_22.7mbps.webm
+
+rm -rf ffmpeg-4.1.3
+rm -rf ffmpeg_
+
+# Build Dav1d
+tar -xf dav1d-0.3.0.tar.xz
+cd dav1d-0.3.0
+meson build --buildtype release
+ninja -C build
+echo $? > ~/install-exit-status
+
+cd ~
+
+echo "#!/bin/sh
+./dav1d-0.3.0/build/tools/dav1d \$@ --muxer null --framethreads \$NUM_CPU_CORES --tilethreads 4 -q --filmgrain 0
+echo \$? > ~/test-exit-status" > dav1d
+chmod +x dav1d

--- a/pts/dav1d-1.2.0/results-definition.xml
+++ b/pts/dav1d-1.2.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.6.0m1-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/dav1d-1.2.0/test-definition.xml
+++ b/pts/dav1d-1.2.0/test-definition.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.6.0m1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>dav1d</Title>
+    <AppVersion>0.3</AppVersion>
+    <Description>Dav1d is an open-source, speedy AV1 video decoder. This test profile times how long it takes to decode some sample AV1 video content.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.2.0</Version>
+    <SupportedPlatforms>Linux, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, yasm, meson</ExternalDependencies>
+    <EnvironmentSize>1100</EnvironmentSize>
+    <ProjectURL>http://code.videolan.org/videolan/dav1d</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments> </Arguments>
+    </Default>
+    <Option>
+      <DisplayName>Video Input</DisplayName>
+      <Identifier>video</Identifier>
+      <ArgumentPrefix>-i </ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>Summer Nature 1080p</Name>
+          <Value>summer_nature_1080p.ivf</Value>
+        </Entry>
+        <Entry>
+          <Name>Summer Nature 4K</Name>
+          <Value>summer_nature_4k.ivf</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
Adds a test profile for the dav1d 0.3.0 release. Changes profile number to 1.2.0, changes from 1.1.0:

Test changes:
 - Updates dav1d to 0.3.0
 - Add -q (silent) and --filmgrain 0 (disable filmgrain) parameters

Setup changes:
 - Update FFmpeg to 4.1.3 (only used for conversion to .ivf)
 - Remove .webm and .mp4 files after they are muxed to .ivf

Replaces #70.