### PR TITLE
pts/twtk-1.0.1: Test name typo

### DIFF
--- a/pts/twtk-1.0.1/test-definition.xml
+++ b/pts/twtk-1.0.1/test-definition.xml
@@ -2,7 +2,7 @@
 <!--Phoronix Test Suite v8.4.0m3-->
 <PhoronixTestSuite>
   <TestInformation>
-    <Title>Total War: Three Kindgoms</Title>
+    <Title>Total War: Three Kingdoms</Title>
     <AppVersion>1.0.1</AppVersion>
     <Description>Total War: Three Kingdoms on Steam.
 


### PR DESCRIPTION
Fixing a typo in the test title.