### PR TITLE
Update SVT-VP9 profile

### DIFF
--- a/pts/svt-vp9-1.1.0/downloads.xml
+++ b/pts/svt-vp9-1.1.0/downloads.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.6.0-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z</URL>
+      <MD5>db7c7ff09acd5d7820cc4d1eb0939cf9</MD5>
+      <SHA256>e73a54088e88e6465f578625d185933e85c3209ab7105deb755a8b8918b78cab</SHA256>
+      <FileName>Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z</FileName>
+      <FileSize>680772328</FileSize>
+    </Package>
+    <Package>
+      <URL>http://www.phoronix-test-suite.com/benchmark-files/SVT-VP9-20190906.zip</URL>
+      <MD5></MD5>
+      <SHA256></SHA256>
+      <FileName>SVT-VP9-20190906.zip</FileName>
+      <FileSize></FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/svt-vp9-1.1.0/install.sh
+++ b/pts/svt-vp9-1.1.0/install.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z
+
+unzip -o SVT-VP9-20190906.zip
+cd SVT-VP9-master/Build/linux
+chmod +x build.sh
+./build.sh release
+echo $? > ~/install-exit-status
+
+cd ~
+
+echo "#!/bin/sh
+./SVT-VP9-master/Bin/Release/SvtVp9EncApp -i Bosphorus_1920x1080_120fps_420_8bit_YUV.yuv -w 1920 -h 1080 > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status" > svt-vp9
+chmod +x svt-vp9

--- a/pts/svt-vp9-1.1.0/results-definition.xml
+++ b/pts/svt-vp9-1.1.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.6.0-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Average Speed:		#_RESULT_# fps</OutputTemplate>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/svt-vp9-1.1.0/test-definition.xml
+++ b/pts/svt-vp9-1.1.0/test-definition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.6.0-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>SVT-VP9</Title>
+    <AppVersion>2019-09-06</AppVersion>
+    <Description>This is a test of the Intel Open Visual Cloud Scalable Video Technology SVT-VP9 CPU-based multi-threaded video encoder for the VP9 video format with a sample 1080p YUV video file.</Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <SubTitle>1080p 8-bit YUV To VP9 Video Encode</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, p7zip, yasm, cmake</ExternalDependencies>
+    <EnvironmentSize>1900</EnvironmentSize>
+    <ProjectURL>http://github.com/OpenVisualCloud/SVT-VP9</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>


### PR DESCRIPTION
New version of the SVT-VP9 profile. The encoder just got a [huge speedup](https://github.com/OpenVisualCloud/SVT-VP9/pull/48) on AVX2 CPUs by enabling SIMD assembly.

@michaellarabel Could you zip and upload a new version of [SVT-VP9](https://github.com/OpenVisualCloud/SVT-VP9/commits/master) to http://www.phoronix-test-suite.com/benchmark-files/ and add the hashes to the `downloads.xml`?