### PR TITLE
Update SVT-AV1 profile with multiple speed presets

### DIFF
--- a/pts/svt-av1-2.0.0/downloads.xml
+++ b/pts/svt-av1-2.0.0/downloads.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.8.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z</URL>
+      <MD5>db7c7ff09acd5d7820cc4d1eb0939cf9</MD5>
+      <SHA256>e73a54088e88e6465f578625d185933e85c3209ab7105deb755a8b8918b78cab</SHA256>
+      <FileName>Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z</FileName>
+      <FileSize>680772328</FileSize>
+    </Package>
+    <Package>
+      <URL>https://github.com/OpenVisualCloud/SVT-AV1/archive/v0.6.0.zip</URL>
+      <MD5>6badc17ae0c22760ffea6382d48ca6d6</MD5>
+      <SHA256>c02af5d1beca94b6395fb54aa38de2615ab61bce1197faa216a5b5cefc7fe6cf</SHA256>
+      <FileName>SVT-AV1-0.6.0.zip</FileName>
+      <FileSize>3039706</FileSize>
+      <PlatformSpecific>Linux</PlatformSpecific>
+    </Package>
+    <Package>
+      <URL>http://phoronix-test-suite.com/benchmark-files/SVT-AV1-0.6-Windows.zip</URL>
+      <MD5></MD5>
+      <SHA256></SHA256>
+      <FileName>SVT-AV1-0.6-Windows.zip</FileName>
+      <FileSize></FileSize>
+      <PlatformSpecific>Windows</PlatformSpecific>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/svt-av1-2.0.0/install.sh
+++ b/pts/svt-av1-2.0.0/install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z
+
+unzip -o SVT-AV1-0.6.0.zip
+cd SVT-AV1-0.6.0/Build/linux
+./build.sh release
+echo $? > ~/install-exit-status
+
+cd ~
+echo "#!/bin/sh
+./SVT-AV1-0.6.0/Bin/Release/SvtAv1EncApp \$@ -i Bosphorus_1920x1080_120fps_420_8bit_YUV.yuv -w 1920 -h 1080 > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status" > svt-av1
+chmod +x svt-av1

--- a/pts/svt-av1-2.0.0/install_windows.sh
+++ b/pts/svt-av1-2.0.0/install_windows.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z
+unzip -o SVT-AV1-0.6-Windows.zip
+
+echo "#!/bin/sh
+./SvtAv1EncApp.exe \$@ -i Bosphorus_1920x1080_120fps_420_8bit_YUV.yuv -w 1920 -h 1080 > \$LOG_FILE 2>&1" > svt-av1
+chmod +x svt-av1

--- a/pts/svt-av1-2.0.0/results-definition.xml
+++ b/pts/svt-av1-2.0.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.8.1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Average Speed:		#_RESULT_# fps</OutputTemplate>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/svt-av1-2.0.0/test-definition.xml
+++ b/pts/svt-av1-2.0.0/test-definition.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.8.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>SVT-AV1</Title>
+    <AppVersion>0.6</AppVersion>
+    <Description>This is a test of the Intel Open Visual Cloud Scalable Video Technology SVT-AV1 CPU-based multi-threaded video encoder for the AV1 video format with a sample 1080p YUV video file.</Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <SubTitle>1080p 8-bit YUV To AV1 Video Encode</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>2.0.0</Version>
+    <SupportedPlatforms>Linux, Windows</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, p7zip, yasm, cmake</ExternalDependencies>
+    <EnvironmentSize>1900</EnvironmentSize>
+    <ProjectURL>http://github.com/OpenVisualCloud/SVT-AV1</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments></Arguments>
+    </Default>
+    <Option>
+      <DisplayName>Encoder Mode (speed)</DisplayName>
+      <Identifier>enc-mode</Identifier>
+      <ArgumentPrefix></ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>Enc Mode 8</Name>
+          <Value>-enc-mode 8 -n 320</Value>
+        </Entry>
+        <Entry>
+          <Name>Enc Mode 4</Name>
+          <Value>-enc-mode 4 -n 80</Value>
+        </Entry>
+        <Entry>
+          <Name>Enc Mode 0</Name>
+          <Value>-enc-mode 0 -n 20</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
 - Add `-enc-mode 4` and `0` speeds tests
 - Update frame counts to 320, 80 and 20 for enc-mode 8, 4 and 0
 - Update to SVT-AV1 0.6.0

@michaellarabel Could you please check if I defined the `test-definition.xml` correctly and add the Windows file details `downloads.xml`? Would be nice if it could make it to the PTS 9.0 release!