### PR TITLE
pts/sqlite-2.1.0: add Thread option to increase test loading

### DIFF
--- a/pts/sqlite-2.1.0/downloads.xml
+++ b/pts/sqlite-2.1.0/downloads.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.0m0-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://sqlite.org/2018/sqlite-autoconf-3220000.tar.gz</URL>
+      <MD5>96b5648d542e8afa6ab7ffb8db8ddc3d</MD5>
+      <SHA256>2824ab1238b706bc66127320afbdffb096361130e23291f26928a027b885c612</SHA256>
+      <FileSize>2644649</FileSize>
+    </Package>
+    <Package>
+      <URL>http://sqlite.org/2018/sqlite-tools-win32-x86-3220000.zip</URL>
+      <MD5>971ee1bba806f0077cbd413e8caed519</MD5>
+      <SHA256>e318d482423913fc8439bc551362372b10234594cf6928bd927fed4c7e79dcbe</SHA256>
+      <FileSize>1701584</FileSize>
+      <PlatformSpecific>Windows</PlatformSpecific>
+    </Package>
+    <Package>
+      <URL>http://www.phoronix-test-suite.com/benchmark-files/pts-sqlite-tests-1.tar.gz, http://www.phoronix.net/downloads/phoronix-test-suite/benchmark-files/pts-sqlite-tests-1.tar.gz</URL>
+      <MD5>153e725642619e38766ddf8359f65cfe</MD5>
+      <SHA256>1067f047461e21fd56e2a6ae03043c687047d00192ffdbe5b52271cd39de442f</SHA256>
+      <FileSize>42835</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/sqlite-2.1.0/install.sh
+++ b/pts/sqlite-2.1.0/install.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+tar -zxvf pts-sqlite-tests-1.tar.gz
+tar -zxvf sqlite-autoconf-3220000.tar.gz
+mkdir sqlite_/
+
+cd sqlite-autoconf-3220000/
+./configure --prefix=$HOME/sqlite_/
+make
+echo $? > ~/install-exit-status
+make install
+cd ..
+rm -rf sqlite-autoconf-3220000/
+
+echo "#!/bin/sh
+
+thread_num=\$1
+cat sqlite-2500-insertions.txt > sqlite-insertions.txt
+
+do_test() {
+    DB=benchmark-\$1.db
+    ./sqlite_/bin/sqlite3 \$DB  \"CREATE TABLE pts1 ('I' SMALLINT NOT NULL, 'DT' TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, 'F1' VARCHAR(4) NOT NULL, 'F2' VARCHAR(16) NOT NULL);\"
+
+    cat sqlite-insertions.txt | ./sqlite_/bin/sqlite3 \$DB
+    cat sqlite-insertions.txt | ./sqlite_/bin/sqlite3 \$DB
+    cat sqlite-insertions.txt | ./sqlite_/bin/sqlite3 \$DB
+}
+
+pids=\"\"
+for i in \$(seq 1 \$thread_num)
+do
+    do_test \$i &
+    pids=\"\$pids $!\"
+done
+
+wait \$pids" > sqlite-benchmark
+chmod +x sqlite-benchmark

--- a/pts/sqlite-2.1.0/install_windows.sh
+++ b/pts/sqlite-2.1.0/install_windows.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+tar -zxvf pts-sqlite-tests-1.tar.gz
+unzip -o sqlite-tools-win32-x86-3220000.zip
+
+echo "#!/bin/sh
+
+thread_num=\$1
+cat sqlite-2500-insertions.txt > sqlite-insertions.txt
+
+do_test() {
+    DB=benchmark-\$1.db
+    ./sqlite-tools-win32-x86-3220000/sqlite3.exe \$DB  \"CREATE TABLE pts1 ('I' SMALLINT NOT NULL, 'DT' TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, 'F1' VARCHAR(4) NOT NULL, 'F2' VARCHAR(16) NOT NULL);\"
+
+    cat sqlite-insertions.txt | ./sqlite-tools-win32-x86-3220000/sqlite3.exe \$DB
+    cat sqlite-insertions.txt | ./sqlite-tools-win32-x86-3220000/sqlite3.exe \$DB
+    cat sqlite-insertions.txt | ./sqlite-tools-win32-x86-3220000/sqlite3.exe \$DB
+}
+
+pids=\"\"
+for i in \$(seq 1 \$thread_num)
+do
+    do_test \$i &
+    pids=\"\$pids $!\"
+done
+
+wait \$pids" > sqlite-benchmark
+chmod +x sqlite-benchmark

--- a/pts/sqlite-2.1.0/interim.sh
+++ b/pts/sqlite-2.1.0/interim.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f benchmark.db

--- a/pts/sqlite-2.1.0/post.sh
+++ b/pts/sqlite-2.1.0/post.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f benchmark-*.db

--- a/pts/sqlite-2.1.0/pre.sh
+++ b/pts/sqlite-2.1.0/pre.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f benchmark-*.db

--- a/pts/sqlite-2.1.0/results-definition.xml
+++ b/pts/sqlite-2.1.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.0m0-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/sqlite-2.1.0/test-definition.xml
+++ b/pts/sqlite-2.1.0/test-definition.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.0.0m0-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>SQLite</Title>
+    <AppVersion>3.22</AppVersion>
+    <Description>This is a simple benchmark of SQLite. At present this test profile just measures the time to perform a pre-defined number of insertions on an indexed database.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <SubTitle>Timed SQLite Insertions</SubTitle>
+    <Executable>sqlite-benchmark</Executable>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>2.1.0</Version>
+    <SupportedPlatforms>Linux, BSD, MacOSX, Solaris, Windows</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>Disk</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities</ExternalDependencies>
+    <EnvironmentSize>22</EnvironmentSize>
+    <ProjectURL>http://www.sqlite.org/</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Thread</DisplayName>
+      <Identifier>thread</Identifier>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>1</Name>
+          <Value>1</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>8</Name>
+          <Value>8</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>32</Name>
+          <Value>32</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>64</Name>
+          <Value>64</Value>
+          <Message></Message>
+        </Entry>
+        <Entry>
+          <Name>128</Name>
+          <Value>128</Value>
+          <Message></Message>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
The default sqlite loading is too light for server. It will take only about 1.5s.
Sometimes the kernel still in idle state, and test result will not stable.

Add Thread option to increase test loading by fork multiple instance at the same time.
It can emulate a server running many sqlite instance, and writing to database at the same time. 