### PR TITLE
Update aom-av1 profile with realtime and two-pass 

### DIFF
--- a/pts/aom-av1-2.0.0/downloads.xml
+++ b/pts/aom-av1-2.0.0/downloads.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.0m3-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z</URL>
+      <MD5>84ae521c95aa2537e16b34bbf72f2def</MD5>
+      <SHA256>e2f60b904789a60f6d1edc194d8540d401dd882e3ee3605b9b1de8feacc72133</SHA256>
+      <FileName>Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z</FileName>
+      <FileSize>676792531</FileSize>
+    </Package>
+    <Package>
+      <URL>http://www.phoronix-test-suite.com/benchmark-files/aom-20190916.tar.xz</URL>
+      <MD5>98cb029a0f862ec3924213668be49844</MD5>
+      <SHA256>f06b269cb4fa4f091b41b0b1deb850b6c6bdd42a58e69d6544b5add581197c36</SHA256>
+      <FileName>aom-20190916.tar.xz</FileName>
+      <FileSize>2321028</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/aom-av1-2.0.0/install.sh
+++ b/pts/aom-av1-2.0.0/install.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+tar -xf aom-20190916.tar.xz
+cd aom-20190916/build
+cmake ..
+make -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+cd ~
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
+
+echo "#!/bin/sh
+./aom-20190916/build/aomenc -v --rt --threads=\$NUM_CPU_CORES --tile-columns=2 --limit=20 -o test.av1 Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m > 1.log 2>&1
+echo \$? > ~/test-exit-status
+sed \$'s/[^[:print:]\t]/\\n/g' 1.log > \$LOG_FILE" > aom-av1
+chmod +x aom-av1

--- a/pts/aom-av1-2.0.0/install.sh
+++ b/pts/aom-av1-2.0.0/install.sh
@@ -10,7 +10,7 @@ cd ~
 7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
 
 echo "#!/bin/sh
-./aom-20190916/build/aomenc -v --rt --threads=\$NUM_CPU_CORES --tile-columns=2 --limit=20 -o test.av1 Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m > 1.log 2>&1
+./aom-20190916/build/aomenc --threads=\$NUM_CPU_CORES -o test.av1 Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m > 1.log 2>&1
 echo \$? > ~/test-exit-status
 sed \$'s/[^[:print:]\t]/\\n/g' 1.log > \$LOG_FILE" > aom-av1
 chmod +x aom-av1

--- a/pts/aom-av1-2.0.0/install.sh
+++ b/pts/aom-av1-2.0.0/install.sh
@@ -10,7 +10,7 @@ cd ~
 7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
 
 echo "#!/bin/sh
-./aom-20190916/build/aomenc --threads=\$NUM_CPU_CORES -o test.av1 Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m > 1.log 2>&1
+./aom-20190916/build/aomenc --threads=\$NUM_CPU_CORES \$@ -o test.av1 Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m > 1.log 2>&1
 echo \$? > ~/test-exit-status
 sed \$'s/[^[:print:]\t]/\\n/g' 1.log > \$LOG_FILE" > aom-av1
 chmod +x aom-av1

--- a/pts/aom-av1-2.0.0/results-definition.xml
+++ b/pts/aom-av1-2.0.0/results-definition.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.0m3-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Pass 1/2 frame    3/4        768B    2048b/f   61440b/s  165907 us #_RESULT_# fps)</OutputTemplate>
+    <LineHint>fps</LineHint>
+    <TurnCharsToSpace>(</TurnCharsToSpace>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/aom-av1-2.0.0/test-definition.xml
+++ b/pts/aom-av1-2.0.0/test-definition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.0m3-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>AOM AV1</Title>
+    <AppVersion>2019-09-16</AppVersion>
+    <Description>This is a simple test of the AOMedia AV1 encoder run on the CPU with a sample video file.</Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <SubTitle>AV1 Video Encoding</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.2.0</Version>
+    <SupportedPlatforms>Linux, MacOSX, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, p7zip, cmake, perl, yasm</ExternalDependencies>
+    <EnvironmentSize>369</EnvironmentSize>
+    <ProjectURL>https://aomedia.googlesource.com/aom/</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/pts/aom-av1-2.0.0/test-definition.xml
+++ b/pts/aom-av1-2.0.0/test-definition.xml
@@ -23,4 +23,36 @@
     <InternalTags>SMP</InternalTags>
     <Maintainer>Michael Larabel</Maintainer>
   </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Encoder Mode</DisplayName>
+      <Identifier>enc-mode</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Speed 8 Realtime</Name>
+          <Value>--cpu-used=8 --rt --limit=240</Value>
+        </Entry>
+        <Entry>
+          <Name>Speed 6 Realtime</Name>
+          <Value>--cpu-used=6 --rt --limit=120</Value>
+        </Entry>
+        <Entry>
+          <Name>Speed 4 Realtime</Name>
+          <Value>--cpu-used=4 --rt --limit=60</Value>
+        </Entry>
+        <Entry>
+          <Name>Speed 4 Two-pass</Name>
+          <Value>--cpu-used=4 --limit=20</Value>
+        </Entry>
+        <Entry>
+          <Name>Speed 2 Realtime</Name>
+          <Value>--cpu-used=2 --limit=20</Value>
+        </Entry>
+        <Entry>
+          <Name>Speed 0 Realtime</Name>
+          <Value>--cpu-used=0 --limit=10</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
 </PhoronixTestSuite>

--- a/pts/aom-av1-2.0.0/test-definition.xml
+++ b/pts/aom-av1-2.0.0/test-definition.xml
@@ -45,11 +45,11 @@
           <Value>--cpu-used=4 --limit=20</Value>
         </Entry>
         <Entry>
-          <Name>Speed 2 Realtime</Name>
+          <Name>Speed 2 Two-pass</Name>
           <Value>--cpu-used=2 --limit=20</Value>
         </Entry>
         <Entry>
-          <Name>Speed 0 Realtime</Name>
+          <Name>Speed 0 Two-pass</Name>
           <Value>--cpu-used=0 --limit=10</Value>
         </Entry>
       </Menu>

--- a/pts/aom-av1-2.0.0/test-definition.xml
+++ b/pts/aom-av1-2.0.0/test-definition.xml
@@ -41,8 +41,8 @@
           <Value>--cpu-used=4 --rt --limit=60</Value>
         </Entry>
         <Entry>
-          <Name>Speed 4 Two-pass</Name>
-          <Value>--cpu-used=4 --limit=20</Value>
+          <Name>Speed 5 Two-pass</Name>
+          <Value>--cpu-used=5 --limit=40</Value>
         </Entry>
         <Entry>
           <Name>Speed 2 Two-pass</Name>


### PR DESCRIPTION
@michaellarabel I updated the aom profile to better represent common use cases. In this effort, I added 3 realtime and 3 high-latency two-pass tests. I think you will be impressed with its performance!

Each profile is designed to take no more than one minute and often less, tested on my quad-core i5-4590.

**3 realtime profiles:**

- `--cpu-used=8 --rt --limit=240`
- `--cpu-used=6 --rt --limit=120`
- `--cpu-used=4 --rt --limit=60`

**3 two-pass profiles:**

- `--cpu-used=5 --limit=40`
- `--cpu-used=2 --limit=20`
- `--cpu-used=0 --limit=10`

I removed the tile-columns since in my testing it doesn't increase speed since row-mt is enabled by default.