### PR TITLE
pts/fio-1.12.1: Minor fixes

### DIFF
--- a/pts/fio-1.12.1/downloads.xml
+++ b/pts/fio-1.12.1/downloads.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://brick.kernel.dk/snaps/fio-3.16.tar.gz</URL>
+      <MD5>ca8eb2c413f7e7ecf70f87dede0ecdc3</MD5>
+      <SHA256>988ba0ed7488968fdccc882ceadd2124370825d0a1317ae4fdd80d5f2acc31da</SHA256>
+      <FileName>fio-3.16.tar.gz</FileName>
+      <FileSize>979997</FileSize>
+      <PlatformSpecific>Linux, BSD, Solaris, MacOSX</PlatformSpecific>
+    </Package>
+    <Package>
+      <URL>https://bsdio.com/fio/releases/fio-3.16-x64.zip</URL>
+      <MD5>1248bc9361170780ccd9d08a88d3cd1b</MD5>
+      <SHA256>688d85ff2287e0503fae3121044ef00a08984d63189de379cc8d3c2640b96d7a</SHA256>
+      <FileName>fio-3.16-x64.zip</FileName>
+      <FileSize>3837780</FileSize>
+      <PlatformSpecific>Windows</PlatformSpecific>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/fio-1.12.1/install.sh
+++ b/pts/fio-1.12.1/install.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+tar -xzf fio-3.16.tar.gz
+cd fio-3.16/
+./configure
+if [ "$OS_TYPE" = "BSD" ]
+then
+	gmake -j $NUM_CPU_JOBS
+else
+	make -j $NUM_CPU_JOBS
+fi
+echo $? > ~/install-exit-status
+cd ~
+
+echo "#!/bin/sh
+cd fio-3.16/
+
+if [ \"X\$6\" = \"X\" ]
+then
+	DIRECTORY_TO_TEST=\"fiofile\"
+else
+	DIRECTORY_TO_TEST=\"\$6\"
+fi
+
+echo \"[global]
+rw=\$1
+ioengine=\$2
+iodepth=64
+size=1g
+direct=\$4
+buffered=\$3
+startdelay=5
+ramp_time=5
+runtime=20
+time_based\" > test.fio
+
+if [ \"\${OPERATING_SYSTEM}\" != \"freebsd\" ]
+then
+	echo \"disk_util=0\" >> test.fio
+fi
+
+echo \"clat_percentiles=0
+disable_lat=1
+disable_clat=1
+disable_slat=1
+filename=\$DIRECTORY_TO_TEST
+
+[test]
+name=test
+bs=\$5
+stonewall\" >> test.fio
+
+./fio test.fio 2>&1 > \$LOG_FILE" > fio-run
+chmod +x fio-run

--- a/pts/fio-1.12.1/install_windows.sh
+++ b/pts/fio-1.12.1/install_windows.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+unzip -o fio-3.16-x64.zip
+mv fio-3.16-x64 fio-3.16
+
+echo "#!/bin/sh
+cd fio-3.16/
+
+if [ ! \"X\$6\" = \"X\" ]
+then
+DIRECTORY_TO_TEST=\"directory=\$6\"
+fi
+
+echo \"[global]
+rw=\$1
+ioengine=\$2
+iodepth=64
+size=1g
+direct=\$4
+buffered=\$3
+startdelay=5
+ramp_time=5
+runtime=20
+time_based
+clat_percentiles=0
+disable_lat=1
+disable_clat=1
+disable_slat=1
+filename=fiofile
+\$DIRECTORY_TO_TEST
+
+[test]
+name=test
+bs=\$5
+stonewall\" > test.fio
+
+./fio.exe test.fio > \$LOG_FILE" > fio-run
+chmod +x fio-run

--- a/pts/fio-1.12.1/interim.sh
+++ b/pts/fio-1.12.1/interim.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd fio-3.1/
+rm -f iometer.0.0

--- a/pts/fio-1.12.1/interim.sh
+++ b/pts/fio-1.12.1/interim.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-cd fio-3.1/
+cd fio-3.16/
 rm -f iometer.0.0

--- a/pts/fio-1.12.1/post.sh
+++ b/pts/fio-1.12.1/post.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd fio-3.1/
+rm -f iometer.0.0

--- a/pts/fio-1.12.1/post.sh
+++ b/pts/fio-1.12.1/post.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-cd fio-3.1/
+cd fio-3.16/
 rm -f iometer.0.0

--- a/pts/fio-1.12.1/pre.sh
+++ b/pts/fio-1.12.1/pre.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd fio-3.1/
+rm -f iometer.0.0

--- a/pts/fio-1.12.1/pre.sh
+++ b/pts/fio-1.12.1/pre.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-cd fio-3.1/
+cd fio-3.16/
 rm -f iometer.0.0

--- a/pts/fio-1.12.1/results-definition.xml
+++ b/pts/fio-1.12.1/results-definition.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>   READ: bw=#_RESULT_# (861MB/s), 821MiB/s-821MiB/s (861MB/s-861MB/s), io=16.4GiB (17.3GB), run=20002-20002msec</OutputTemplate>
+    <LineHint>: bw=</LineHint>
+    <ResultAfterString>bw</ResultAfterString>
+    <StripFromResult>KiB/s</StripFromResult>
+    <DivideResultBy>1000</DivideResultBy>
+    <ResultScale>MB/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>   READ: bw=#_RESULT_# (861MB/s), 821MiB/s-821MiB/s (861MB/s-861MB/s), io=16.4GiB (17.3GB), run=20002-20002msec</OutputTemplate>
+    <LineHint>: bw=</LineHint>
+    <ResultAfterString>bw</ResultAfterString>
+    <StripFromResult>MiB/s</StripFromResult>
+    <ResultScale>MB/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>  write: IOPS=#_RESULT_# BW=891MiB/s (934MB/s)(17.5GiB/20006msec)</OutputTemplate>
+    <LineHint>IOPS=</LineHint>
+    <ResultAfterString>IOPS</ResultAfterString>
+    <StripFromResult>k,</StripFromResult>
+    <MultiplyResultBy>1000</MultiplyResultBy>
+    <ResultScale>IOPS</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/fio-1.12.1/results-definition.xml
+++ b/pts/fio-1.12.1/results-definition.xml
@@ -22,6 +22,14 @@
     <OutputTemplate>  write: IOPS=#_RESULT_# BW=891MiB/s (934MB/s)(17.5GiB/20006msec)</OutputTemplate>
     <LineHint>IOPS=</LineHint>
     <ResultAfterString>IOPS</ResultAfterString>
+    <StripFromResult>,</StripFromResult>
+    <ResultScale>IOPS</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>  write: IOPS=#_RESULT_# BW=891MiB/s (934MB/s)(17.5GiB/20006msec)</OutputTemplate>
+    <LineHint>IOPS=</LineHint>
+    <ResultAfterString>IOPS</ResultAfterString>
     <StripFromResult>k,</StripFromResult>
     <MultiplyResultBy>1000</MultiplyResultBy>
     <ResultScale>IOPS</ResultScale>

--- a/pts/fio-1.12.1/test-definition.xml
+++ b/pts/fio-1.12.1/test-definition.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Flexible IO Tester</Title>
+    <AppVersion>3.16</AppVersion>
+    <Description>Fio is an advanced disk benchmark that depends upon the kernel's AIO access library.</Description>
+    <Executable>fio-run</Executable>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.12.1</Version>
+    <SupportedPlatforms>Linux, BSD, MacOSX, Windows</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>Disk</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, libaio-development</ExternalDependencies>
+    <EnvironmentSize>4</EnvironmentSize>
+    <ProjectURL>http://github.com/axboe/fio</ProjectURL>
+    <RequiresCoreVersionMin>6921</RequiresCoreVersionMin>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Type</DisplayName>
+      <Identifier>type</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Random Read</Name>
+          <Value>randread</Value>
+        </Entry>
+        <Entry>
+          <Name>Random Write</Name>
+          <Value>randwrite</Value>
+        </Entry>
+        <Entry>
+          <Name>Sequential Read</Name>
+          <Value>read</Value>
+        </Entry>
+        <Entry>
+          <Name>Sequential Write</Name>
+          <Value>write</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>IO Engine</DisplayName>
+      <Identifier>engine</Identifier>
+      <Menu>
+        <Entry>
+          <Name>POSIX AIO</Name>
+          <Value>posixaio</Value>
+        </Entry>
+        <Entry>
+          <Name>Sync</Name>
+          <Value>sync</Value>
+        </Entry>
+        <Entry>
+          <Name>Linux AIO</Name>
+          <Value>libaio</Value>
+        </Entry>
+        <Entry>
+          <Name>Windows AIO</Name>
+          <Value>windowsaio</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Buffered</DisplayName>
+      <Identifier>buffered</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Yes</Name>
+          <Value>1</Value>
+        </Entry>
+        <Entry>
+          <Name>No</Name>
+          <Value>0</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Direct</DisplayName>
+      <Identifier>direct</Identifier>
+      <Menu>
+        <Entry>
+          <Name>No</Name>
+          <Value>0</Value>
+        </Entry>
+        <Entry>
+          <Name>Yes</Name>
+          <Value>1</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Block Size</DisplayName>
+      <Identifier>size</Identifier>
+      <Menu>
+        <Entry>
+          <Name>4KB</Name>
+          <Value>4k</Value>
+        </Entry>
+        <Entry>
+          <Name>8KB</Name>
+          <Value>8k</Value>
+        </Entry>
+        <Entry>
+          <Name>16KB</Name>
+          <Value>16k</Value>
+        </Entry>
+        <Entry>
+          <Name>32KB</Name>
+          <Value>32k</Value>
+        </Entry>
+        <Entry>
+          <Name>64KB</Name>
+          <Value>64k</Value>
+        </Entry>
+        <Entry>
+          <Name>128KB</Name>
+          <Value>128k</Value>
+        </Entry>
+        <Entry>
+          <Name>256KB</Name>
+          <Value>256k</Value>
+        </Entry>
+        <Entry>
+          <Name>512KB</Name>
+          <Value>512k</Value>
+        </Entry>
+        <Entry>
+          <Name>1MB</Name>
+          <Value>1m</Value>
+        </Entry>
+        <Entry>
+          <Name>2MB</Name>
+          <Value>2m</Value>
+        </Entry>
+        <Entry>
+          <Name>4MB</Name>
+          <Value>4m</Value>
+        </Entry>
+        <Entry>
+          <Name>8MB</Name>
+          <Value>8m</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Disk Target</DisplayName>
+      <Identifier>auto-disk-mount-points</Identifier>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
This PR fixes:

  - File not found errors when running {pre,post,interim} scripts.
  - IOPS results not being returned if they are displayed by FIO without the `k` suffix (for small IOPS values).