### PR TITLE
Update Rav1e version, add speed levels

### DIFF
--- a/pts/rav1e-1.2.0/downloads.xml
+++ b/pts/rav1e-1.2.0/downloads.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z</URL>
+      <MD5>84ae521c95aa2537e16b34bbf72f2def</MD5>
+      <SHA256>e2f60b904789a60f6d1edc194d8540d401dd882e3ee3605b9b1de8feacc72133</SHA256>
+      <FileName>Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z</FileName>
+      <FileSize>676792531</FileSize>
+    </Package>
+    <Package>
+      <URL>https://github.com/xiph/rav1e/archive/0.1.0.tar.gz</URL>
+      <MD5>cd383e61e86eef0a689c9c951a4c7652</MD5>
+      <SHA256>00395087eaba4778d17878924e007716e2f399116b8011bf057fd54cc528a6cb</SHA256>
+      <FileName>rav1e-0.1.0.tar.gz</FileName>
+      <FileSize>637375</FileSize>
+      <PlatformSpecific>Linux</PlatformSpecific>
+    </Package>
+    <Package>
+      <URL>https://github.com/xiph/rav1e/releases/download/0.1.0/rav1e.exe</URL>
+      <MD5>7236d84cab5f9c5ecbbf9bdd6a34c161</MD5>
+      <SHA256>0956b4576536e30808346efcc74d4f6ab66c51e884eb9c3e4c2ae57181e233f3</SHA256>
+      <FileName>rav1e-01.exe</FileName>
+      <FileSize>4627456</FileSize>
+      <PlatformSpecific>Windows</PlatformSpecific>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/rav1e-1.2.0/downloads.xml
+++ b/pts/rav1e-1.2.0/downloads.xml
@@ -13,7 +13,7 @@
       <URL>https://github.com/xiph/rav1e/archive/p20191215.tar.gz</URL>
       <MD5>da64341dcee2010993cd0d1d49dc2f12</MD5>
       <SHA256>4d4419bff66b29e228cb2b373bcd37f74cfbc33ed834dec1ffc0ba3723330ef8</SHA256>
-      <FileName>rav1e-p20191201.tar.gz</FileName>
+      <FileName>rav1e-p20191215.tar.gz</FileName>
       <FileSize>725822</FileSize>
       <PlatformSpecific>Linux</PlatformSpecific>
     </Package>

--- a/pts/rav1e-1.2.0/downloads.xml
+++ b/pts/rav1e-1.2.0/downloads.xml
@@ -10,17 +10,17 @@
       <FileSize>676792531</FileSize>
     </Package>
     <Package>
-      <URL>https://github.com/xiph/rav1e/archive/p20191201.tar.gz</URL>
-      <MD5>bc23c8a7c9f24edcd4b1373c93351965</MD5>
-      <SHA256>ed190a95830e8af3a0b377d3abf82948d8bf4ca9d752c1f4d1ce25ded743b597</SHA256>
+      <URL>https://github.com/xiph/rav1e/archive/p20191215.tar.gz</URL>
+      <MD5>da64341dcee2010993cd0d1d49dc2f12</MD5>
+      <SHA256>4d4419bff66b29e228cb2b373bcd37f74cfbc33ed834dec1ffc0ba3723330ef8</SHA256>
       <FileName>rav1e-p20191201.tar.gz</FileName>
       <FileSize>725822</FileSize>
       <PlatformSpecific>Linux</PlatformSpecific>
     </Package>
     <Package>
-      <URL>https://github.com/xiph/rav1e/releases/download/0.1.0/rav1e.exe</URL>
-      <MD5>7923527e414880afbdc92ba85550fb5b</MD5>
-      <SHA256>81bb022b99b8811501ebce6c3b035f7ea2f83100df57dd612085a7754037652c</SHA256>
+      <URL>https://github.com/xiph/rav1e/releases/download/p20191215/rav1e.exe</URL>
+      <MD5>59d354e0e6043a67c31421f464be28f5</MD5>
+      <SHA256>6c0b9cc00f16d0ba727a17d9f2202de66ea9a2fab8ff91a8627a18e67b781e81</SHA256>
       <FileName>rav1e.exe</FileName>
       <FileSize>4648960</FileSize>
       <PlatformSpecific>Windows</PlatformSpecific>

--- a/pts/rav1e-1.2.0/downloads.xml
+++ b/pts/rav1e-1.2.0/downloads.xml
@@ -19,8 +19,8 @@
     </Package>
     <Package>
       <URL>https://github.com/xiph/rav1e/releases/download/v0.2.0/rav1e.exe</URL>
-      <MD5>d6a1f325f3f3208a8c2e9ec5245b5a75</MD5>
-      <SHA256>b7c3e4e269386ef667a4d98346a81f2bb567123f77ec26bfe5a0bbc8e75a7ea1</SHA256>
+      <MD5>5d5158f2c0d160bc2f60a726c6d69bcb</MD5>
+      <SHA256>219af50f35b7fa2ba5fa348cd4f64e158ce5f86b7e672356ba63020d47c8710a</SHA256>
       <FileName>rav1e.exe</FileName>
       <FileSize>4680704</FileSize>
       <PlatformSpecific>Windows</PlatformSpecific>

--- a/pts/rav1e-1.2.0/downloads.xml
+++ b/pts/rav1e-1.2.0/downloads.xml
@@ -10,19 +10,19 @@
       <FileSize>676792531</FileSize>
     </Package>
     <Package>
-      <URL>https://github.com/xiph/rav1e/archive/0.1.0.tar.gz</URL>
-      <MD5>cd383e61e86eef0a689c9c951a4c7652</MD5>
-      <SHA256>00395087eaba4778d17878924e007716e2f399116b8011bf057fd54cc528a6cb</SHA256>
-      <FileName>rav1e-0.1.0.tar.gz</FileName>
-      <FileSize>637375</FileSize>
+      <URL>https://github.com/xiph/rav1e/archive/p20191201.tar.gz</URL>
+      <MD5>bc23c8a7c9f24edcd4b1373c93351965</MD5>
+      <SHA256>ed190a95830e8af3a0b377d3abf82948d8bf4ca9d752c1f4d1ce25ded743b597</SHA256>
+      <FileName>rav1e-p20191201.tar.gz</FileName>
+      <FileSize>725822</FileSize>
       <PlatformSpecific>Linux</PlatformSpecific>
     </Package>
     <Package>
       <URL>https://github.com/xiph/rav1e/releases/download/0.1.0/rav1e.exe</URL>
-      <MD5>7236d84cab5f9c5ecbbf9bdd6a34c161</MD5>
-      <SHA256>0956b4576536e30808346efcc74d4f6ab66c51e884eb9c3e4c2ae57181e233f3</SHA256>
-      <FileName>rav1e-01.exe</FileName>
-      <FileSize>4627456</FileSize>
+      <MD5>7923527e414880afbdc92ba85550fb5b</MD5>
+      <SHA256>81bb022b99b8811501ebce6c3b035f7ea2f83100df57dd612085a7754037652c</SHA256>
+      <FileName>rav1e.exe</FileName>
+      <FileSize>4648960</FileSize>
       <PlatformSpecific>Windows</PlatformSpecific>
     </Package>
   </Downloads>

--- a/pts/rav1e-1.2.0/downloads.xml
+++ b/pts/rav1e-1.2.0/downloads.xml
@@ -10,19 +10,19 @@
       <FileSize>676792531</FileSize>
     </Package>
     <Package>
-      <URL>https://github.com/xiph/rav1e/archive/p20191215.tar.gz</URL>
-      <MD5>da64341dcee2010993cd0d1d49dc2f12</MD5>
-      <SHA256>4d4419bff66b29e228cb2b373bcd37f74cfbc33ed834dec1ffc0ba3723330ef8</SHA256>
-      <FileName>rav1e-p20191215.tar.gz</FileName>
-      <FileSize>725822</FileSize>
+      <URL>https://github.com/xiph/rav1e/archive/v0.2.0.tar.gz</URL>
+      <MD5>3b8a1727955f2244dfc7cb76413f93e2</MD5>
+      <SHA256>c0fa8ee189f506c1a2dfd4b497ebb4e52739e850e1ecce7c02e6bc1073e63d66</SHA256>
+      <FileName>rav1e-v0.2.0.tar.gz</FileName>
+      <FileSize>742651</FileSize>
       <PlatformSpecific>Linux</PlatformSpecific>
     </Package>
     <Package>
-      <URL>https://github.com/xiph/rav1e/releases/download/p20191215/rav1e.exe</URL>
-      <MD5>59d354e0e6043a67c31421f464be28f5</MD5>
-      <SHA256>6c0b9cc00f16d0ba727a17d9f2202de66ea9a2fab8ff91a8627a18e67b781e81</SHA256>
+      <URL>https://github.com/xiph/rav1e/releases/download/v0.2.0/rav1e.exe</URL>
+      <MD5>d6a1f325f3f3208a8c2e9ec5245b5a75</MD5>
+      <SHA256>b7c3e4e269386ef667a4d98346a81f2bb567123f77ec26bfe5a0bbc8e75a7ea1</SHA256>
       <FileName>rav1e.exe</FileName>
-      <FileSize>4648960</FileSize>
+      <FileSize>4680704</FileSize>
       <PlatformSpecific>Windows</PlatformSpecific>
     </Package>
   </Downloads>

--- a/pts/rav1e-1.2.0/install.sh
+++ b/pts/rav1e-1.2.0/install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
+
+tar -xf rav1e-0.1.0.tar.gz
+cd rav1e-0.1.0
+cargo build --bin rav1e --release -j $NUM_CPU_PHYSICAL_CORES
+echo $? > ~/install-exit-status
+
+cd ~
+echo "#!/bin/sh
+cd rav1e-0.1.0
+./target/release/rav1e ../Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES --tile-rows 4 --tile-cols 4 --output /dev/null --limit 60 > log.out 2>&1
+echo \$? > ~/test-exit-status
+
+tr -s '\r' '\n' < log.out > \$LOG_FILE" > rav1e
+chmod +x rav1e

--- a/pts/rav1e-1.2.0/install.sh
+++ b/pts/rav1e-1.2.0/install.sh
@@ -2,14 +2,14 @@
 
 7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
 
-tar -xf rav1e-p20191201.tar.gz
-cd rav1e-p20191201
+tar -xf rav1e-p20191215.tar.gz
+cd rav1e-p20191215
 cargo build --bin rav1e --release -j $NUM_CPU_PHYSICAL_CORES
 echo $? > ~/install-exit-status
 
 cd ~
 echo "#!/bin/sh
-cd rav1e-p20191201
+cd rav1e-p20191215
 ./target/release/rav1e ../Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES -tiles 4 --output /dev/null > log.out 2>&1
 echo \$? > ~/test-exit-status
 

--- a/pts/rav1e-1.2.0/install.sh
+++ b/pts/rav1e-1.2.0/install.sh
@@ -2,14 +2,14 @@
 
 7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
 
-tar -xf rav1e-0.1.0.tar.gz
-cd rav1e-0.1.0
+tar -xf rav1e-p20191201.tar.gz
+cd rav1e-p20191201
 cargo build --bin rav1e --release -j $NUM_CPU_PHYSICAL_CORES
 echo $? > ~/install-exit-status
 
 cd ~
 echo "#!/bin/sh
-cd rav1e-0.1.0
+cd rav1e-p20191201
 ./target/release/rav1e ../Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES --tile-rows 4 --tile-cols 4 --output /dev/null --limit 60 > log.out 2>&1
 echo \$? > ~/test-exit-status
 

--- a/pts/rav1e-1.2.0/install.sh
+++ b/pts/rav1e-1.2.0/install.sh
@@ -2,14 +2,14 @@
 
 7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
 
-tar -xf rav1e-p20191215.tar.gz
-cd rav1e-p20191215
+tar -xf rav1e-v0.2.0.tar.gz
+cd rav1e-v0.2.0
 cargo build --bin rav1e --release -j $NUM_CPU_PHYSICAL_CORES
 echo $? > ~/install-exit-status
 
 cd ~
 echo "#!/bin/sh
-cd rav1e-p20191215
+cd rav1e-v0.2.0
 ./target/release/rav1e ../Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES -tiles 4 --output /dev/null > log.out 2>&1
 echo \$? > ~/test-exit-status
 

--- a/pts/rav1e-1.2.0/install.sh
+++ b/pts/rav1e-1.2.0/install.sh
@@ -10,7 +10,7 @@ echo $? > ~/install-exit-status
 cd ~
 echo "#!/bin/sh
 cd rav1e-p20191201
-./target/release/rav1e ../Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES --tile-rows 4 --tile-cols 4 --output /dev/null --limit 60 > log.out 2>&1
+./target/release/rav1e ../Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES -tiles 4 --output /dev/null > log.out 2>&1
 echo \$? > ~/test-exit-status
 
 tr -s '\r' '\n' < log.out > \$LOG_FILE" > rav1e

--- a/pts/rav1e-1.2.0/install_windows.sh
+++ b/pts/rav1e-1.2.0/install_windows.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
+
+echo "#!/bin/sh
+./rav1e-01.exe Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES --tile-rows 4 --tile-cols 4 --output output --limit 60 > log.out 2>&1
+rm -f output
+
+tr -s '\r' '\n' < log.out > \$LOG_FILE" > rav1e
+chmod +x rav1e

--- a/pts/rav1e-1.2.0/install_windows.sh
+++ b/pts/rav1e-1.2.0/install_windows.sh
@@ -3,7 +3,7 @@
 7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
 
 echo "#!/bin/sh
-./rav1e.exe Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES --tile-rows 4 --tile-cols 4 --output output --limit 60 > log.out 2>&1
+./rav1e.exe Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES -tiles 4 --output NULL.ivf > log.out 2>&1
 rm -f output
 
 tr -s '\r' '\n' < log.out > \$LOG_FILE" > rav1e

--- a/pts/rav1e-1.2.0/install_windows.sh
+++ b/pts/rav1e-1.2.0/install_windows.sh
@@ -3,7 +3,7 @@
 7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_Y4M.7z
 
 echo "#!/bin/sh
-./rav1e-01.exe Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES --tile-rows 4 --tile-cols 4 --output output --limit 60 > log.out 2>&1
+./rav1e.exe Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m --threads \$NUM_CPU_CORES --tile-rows 4 --tile-cols 4 --output output --limit 60 > log.out 2>&1
 rm -f output
 
 tr -s '\r' '\n' < log.out > \$LOG_FILE" > rav1e

--- a/pts/rav1e-1.2.0/results-definition.xml
+++ b/pts/rav1e-1.2.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>encoded 60/60 frames, #_RESULT_# fps, 2306.73 Kb/s, est. size: 0.27 MB, est. time: 0s                    </OutputTemplate>
+    <LineHint>encoded 60/60</LineHint>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/rav1e-1.2.0/test-definition.xml
+++ b/pts/rav1e-1.2.0/test-definition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.0m1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>rav1e</Title>
+    <AppVersion>0.1</AppVersion>
+    <Description>Xiph rav1e is a Rust-written AV1 video encoder.</Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <SubTitle>1080p To AV1 Video Encode</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.0</Version>
+    <SupportedPlatforms>Linux, Windows</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>rust, yasm, perl, cmake</ExternalDependencies>
+    <EnvironmentSize>3000</EnvironmentSize>
+    <ProjectURL>https://github.com/xiph/rav1e</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/pts/rav1e-1.2.0/test-definition.xml
+++ b/pts/rav1e-1.2.0/test-definition.xml
@@ -30,17 +30,17 @@
     <Menu>
       <Entry>
         <Name>Speed 9</Name>
-        <Value>-s 9 -n 80</Value>
+        <Value>-s 9 -l 80</Value>
         <Message>Fastest</Message>
       </Entry>
       <Entry>
         <Name>Speed 5</Name>
-        <Value>-s 5 -n 60</Value>
+        <Value>-s 5 -l 60</Value>
         <Message>Mid-Speed</Message>
       </Entry>
       <Entry>
         <Name>Speed 1</Name>
-        <Value>-s 1 -n 20</Value>
+        <Value>-s 1 -l 20</Value>
         <Message>Slowest</Message>
       </Entry>
     </Menu>

--- a/pts/rav1e-1.2.0/test-definition.xml
+++ b/pts/rav1e-1.2.0/test-definition.xml
@@ -3,7 +3,7 @@
 <PhoronixTestSuite>
   <TestInformation>
     <Title>rav1e</Title>
-    <AppVersion>p20191215</AppVersion>
+    <AppVersion>v0.2.0</AppVersion>
     <Description>Xiph rav1e is a Rust-written AV1 video encoder.</Description>
     <ResultScale>Frames Per Second</ResultScale>
     <Proportion>HIB</Proportion>

--- a/pts/rav1e-1.2.0/test-definition.xml
+++ b/pts/rav1e-1.2.0/test-definition.xml
@@ -3,7 +3,7 @@
 <PhoronixTestSuite>
   <TestInformation>
     <Title>rav1e</Title>
-    <AppVersion>p20191201</AppVersion>
+    <AppVersion>p20191215</AppVersion>
     <Description>Xiph rav1e is a Rust-written AV1 video encoder.</Description>
     <ResultScale>Frames Per Second</ResultScale>
     <Proportion>HIB</Proportion>

--- a/pts/rav1e-1.2.0/test-definition.xml
+++ b/pts/rav1e-1.2.0/test-definition.xml
@@ -23,4 +23,27 @@
     <InternalTags>SMP</InternalTags>
     <Maintainer>Michael Larabel</Maintainer>
   </TestProfile>
+  <TestSettings>
+  <Option>
+    <DisplayName>Speed</DisplayName>
+    <Identifier>s</Identifier>
+    <Menu>
+      <Entry>
+        <Name>Speed 9</Name>
+        <Value>-s 9 -n 80</Value>
+        <Message>Fastest</Message>
+      </Entry>
+      <Entry>
+        <Name>Speed 5</Name>
+        <Value>-s 5 -n 60</Value>
+        <Message>Mid-Speed</Message>
+      </Entry>
+      <Entry>
+        <Name>Speed 1</Name>
+        <Value>-s 1 -n 20</Value>
+        <Message>Slowest</Message>
+      </Entry>
+    </Menu>
+  </Option>
+</TestSettings>
 </PhoronixTestSuite>

--- a/pts/rav1e-1.2.0/test-definition.xml
+++ b/pts/rav1e-1.2.0/test-definition.xml
@@ -3,7 +3,7 @@
 <PhoronixTestSuite>
   <TestInformation>
     <Title>rav1e</Title>
-    <AppVersion>0.1</AppVersion>
+    <AppVersion>p20191201</AppVersion>
     <Description>Xiph rav1e is a Rust-written AV1 video encoder.</Description>
     <ResultScale>Frames Per Second</ResultScale>
     <Proportion>HIB</Proportion>
@@ -11,7 +11,7 @@
     <TimesToRun>3</TimesToRun>
   </TestInformation>
   <TestProfile>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <SupportedPlatforms>Linux, Windows</SupportedPlatforms>
     <SoftwareType>Utility</SoftwareType>
     <TestType>Processor</TestType>


### PR DESCRIPTION
 - Updated to rav1e ~[p20191201](https://github.com/xiph/rav1e/releases/tag/p20191215)~ [p20191215](https://github.com/xiph/rav1e/tree/p20191215)
 - Reduce number of tiles from 4^2 by 4^2 = 256 to a more sensible number of 4 (2 by 2)
 - Introduce 3 speed levels: Speed 9, 5 and 1 (9 is fast, 1 is very slow)