### PR TITLE
Update libvpx version, add speed levels

### DIFF
--- a/pts/vpxenc-3.0.0/downloads.xml
+++ b/pts/vpxenc-3.0.0/downloads.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.0m3-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/webmproject/libvpx/archive/v1.8.1.tar.gz</URL>
+      <MD5>17b1b9278b5066ecd1a76e82266ecdf9</MD5>
+      <SHA256>df19b8f24758e90640e1ab228ab4a4676ec3df19d23e4593375e6f3847dee03e</SHA256>
+      <FileName>libvpx-1.8.1.tar.gz</FileName>
+      <FileSize>2879302</FileSize>
+    </Package>
+    <Package>
+      <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z</URL>
+      <MD5>db7c7ff09acd5d7820cc4d1eb0939cf9</MD5>
+      <SHA256>e73a54088e88e6465f578625d185933e85c3209ab7105deb755a8b8918b78cab</SHA256>
+      <FileName>Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z</FileName>
+      <FileSize>680772328</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/vpxenc-3.0.0/downloads.xml
+++ b/pts/vpxenc-3.0.0/downloads.xml
@@ -3,11 +3,11 @@
 <PhoronixTestSuite>
   <Downloads>
     <Package>
-      <URL>https://github.com/webmproject/libvpx/archive/v1.8.1.tar.gz</URL>
-      <MD5>17b1b9278b5066ecd1a76e82266ecdf9</MD5>
-      <SHA256>df19b8f24758e90640e1ab228ab4a4676ec3df19d23e4593375e6f3847dee03e</SHA256>
-      <FileName>libvpx-1.8.1.tar.gz</FileName>
-      <FileSize>2879302</FileSize>
+      <URL>https://github.com/webmproject/libvpx/archive/v1.8.2.tar.gz</URL>
+      <MD5>6dbccca688886c66a216d7e445525bce</MD5>
+      <SHA256>8735d9fcd1a781ae6917f28f239a8aa358ce4864ba113ea18af4bb2dc8b474ac</SHA256>
+      <FileName>libvpx-1.8.2.tar.gz</FileName>
+      <FileSize>5312988</FileSize>
     </Package>
     <Package>
       <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z</URL>

--- a/pts/vpxenc-3.0.0/install.sh
+++ b/pts/vpxenc-3.0.0/install.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+tar -xzf libvpx-1.8.1.tar.gz
+
+mkdir vpx
+cd libvpx-1.8.1
+
+./configure --disable-install-docs --enable-shared --prefix=$HOME/vpx
+make -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+make install
+cd ~
+rm -rf libvpx-1.8.1
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z
+
+echo "#!/bin/bash
+cd vpx/bin
+THREADCOUNT=\$((\$NUM_CPU_CORES>64?64:\$NUM_CPU_CORES))
+LD_PRELOAD=../lib/libvpx.so  ./vpxenc --codec=vp9 -v --threads=\$THREADCOUNT --tile-columns=6 --row-mt=1 -o /dev/null ~/Bosphorus_1920x1080_120fps_420_8bit_YUV.yuv --width=1920 --height=1080 2> \$LOG_FILE
+echo \$? > ~/test-exit-status" > vpxenc
+chmod +x vpxenc

--- a/pts/vpxenc-3.0.0/install.sh
+++ b/pts/vpxenc-3.0.0/install.sh
@@ -17,6 +17,6 @@ rm -rf libvpx-1.8.2
 echo "#!/bin/bash
 cd vpx/bin
 THREADCOUNT=\$((\$NUM_CPU_CORES>64?64:\$NUM_CPU_CORES))
-LD_PRELOAD=../lib/libvpx.so  ./vpxenc -o /dev/null ~/Bosphorus_1920x1080_120fps_420_8bit_YUV.yuv --width=1920 --height=1080 2> \$LOG_FILE
+LD_PRELOAD=../lib/libvpx.so  ./vpxenc \$@ -o /dev/null ~/Bosphorus_1920x1080_120fps_420_8bit_YUV.yuv --width=1920 --height=1080 2> \$LOG_FILE
 echo \$? > ~/test-exit-status" > vpxenc
 chmod +x vpxenc

--- a/pts/vpxenc-3.0.0/install.sh
+++ b/pts/vpxenc-3.0.0/install.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
-tar -xzf libvpx-1.8.1.tar.gz
+tar -xzf libvpx-1.8.2.tar.gz
 
 mkdir vpx
-cd libvpx-1.8.1
+cd libvpx-1.8.2
 
 ./configure --disable-install-docs --enable-shared --prefix=$HOME/vpx
 make -j $NUM_CPU_CORES
 echo $? > ~/install-exit-status
 make install
 cd ~
-rm -rf libvpx-1.8.1
+rm -rf libvpx-1.8.2
 
 7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z
 

--- a/pts/vpxenc-3.0.0/install.sh
+++ b/pts/vpxenc-3.0.0/install.sh
@@ -5,7 +5,7 @@ tar -xzf libvpx-1.8.2.tar.gz
 mkdir vpx
 cd libvpx-1.8.2
 
-./configure --disable-install-docs --enable-shared --prefix=$HOME/vpx
+./configure --disable-install-docs --disable-vp8 --enable-shared --prefix=$HOME/vpx
 make -j $NUM_CPU_CORES
 echo $? > ~/install-exit-status
 make install
@@ -17,6 +17,6 @@ rm -rf libvpx-1.8.2
 echo "#!/bin/bash
 cd vpx/bin
 THREADCOUNT=\$((\$NUM_CPU_CORES>64?64:\$NUM_CPU_CORES))
-LD_PRELOAD=../lib/libvpx.so  ./vpxenc --codec=vp9 -v --threads=\$THREADCOUNT --tile-columns=6 --row-mt=1 -o /dev/null ~/Bosphorus_1920x1080_120fps_420_8bit_YUV.yuv --width=1920 --height=1080 2> \$LOG_FILE
+LD_PRELOAD=../lib/libvpx.so  ./vpxenc -o /dev/null ~/Bosphorus_1920x1080_120fps_420_8bit_YUV.yuv --width=1920 --height=1080 2> \$LOG_FILE
 echo \$? > ~/test-exit-status" > vpxenc
 chmod +x vpxenc

--- a/pts/vpxenc-3.0.0/results-definition.xml
+++ b/pts/vpxenc-3.0.0/results-definition.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.0m3-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Pass 1/2 frame  600/601   125008B    1666b/f   50003b/s   35453 ms (#_RESULT_# fps)</OutputTemplate>
+    <LineHint> fps</LineHint>
+    <ResultBeforeString>fps</ResultBeforeString>
+    <StripFromResult>(</StripFromResult>
+    <DeleteOutputBefore>600/600</DeleteOutputBefore>
+    <DeleteOutputAfter>Pass 2</DeleteOutputAfter>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/vpxenc-3.0.0/test-definition.xml
+++ b/pts/vpxenc-3.0.0/test-definition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.0m3-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>VP9 libvpx Encoding</Title>
+    <AppVersion>1.8.1</AppVersion>
+    <Description>This is a standard video encoding performance test of Google's libvpx library and the vpxenc command for the VP9/WebM format using a sample 1080p video.</Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <SubTitle>vpxenc VP9 1080p Video Encode</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>2.5.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, yasm, p7zip</ExternalDependencies>
+    <EnvironmentSize>827</EnvironmentSize>
+    <ProjectURL>http://www.webmproject.org/</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/pts/vpxenc-3.0.0/test-definition.xml
+++ b/pts/vpxenc-3.0.0/test-definition.xml
@@ -3,7 +3,7 @@
 <PhoronixTestSuite>
   <TestInformation>
     <Title>VP9 libvpx Encoding</Title>
-    <AppVersion>1.8.1</AppVersion>
+    <AppVersion>1.8.2</AppVersion>
     <Description>This is a standard video encoding performance test of Google's libvpx library and the vpxenc command for the VP9/WebM format using a sample 1080p video.</Description>
     <ResultScale>Frames Per Second</ResultScale>
     <Proportion>HIB</Proportion>
@@ -11,14 +11,14 @@
     <TimesToRun>3</TimesToRun>
   </TestInformation>
   <TestProfile>
-    <Version>2.5.0</Version>
+    <Version>3.0.0</Version>
     <SupportedPlatforms>Linux</SupportedPlatforms>
     <SoftwareType>Utility</SoftwareType>
     <TestType>Processor</TestType>
     <License>Free</License>
     <Status>Verified</Status>
     <ExternalDependencies>build-utilities, yasm, p7zip</ExternalDependencies>
-    <EnvironmentSize>827</EnvironmentSize>
+    <EnvironmentSize>830</EnvironmentSize>
     <ProjectURL>http://www.webmproject.org/</ProjectURL>
     <InternalTags>SMP</InternalTags>
     <Maintainer>Michael Larabel</Maintainer>

--- a/pts/vpxenc-3.0.0/test-definition.xml
+++ b/pts/vpxenc-3.0.0/test-definition.xml
@@ -23,4 +23,22 @@
     <InternalTags>SMP</InternalTags>
     <Maintainer>Michael Larabel</Maintainer>
   </TestProfile>
+  <TestSettings>
+   <Option>
+     <DisplayName>Speed</DisplayName>
+     <Identifier>cpu-used</Identifier>
+     <Menu>
+       <Entry>
+         <Name>Speed 5</Name>
+         <Value>--cpu-used=5</Value>
+         <Message>Fastest - Default</Message>
+       </Entry>
+       <Entry>
+         <Name>Speed 0</Name>
+         <Value>--cpu-used=0</Value>
+         <Message>Slowest</Message>
+       </Entry>
+     </Menu>
+   </Option>
+ </TestSettings>
 </PhoronixTestSuite>


### PR DESCRIPTION
- Update to libvpx 1.8.2
- Adds two speed levels: Speed 5 and Speed 0
- Removed parameters that are either enabled by default or do not increase encoding speed