### PR TITLE
upgrade scikit-learn benchmark version to 0.22.1

### DIFF
--- a/pts/scikit-learn-1.0.2/downloads.xml
+++ b/pts/scikit-learn-1.0.2/downloads.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m2-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/scikit-learn/scikit-learn/archive/0.22.1/scikit-learn-0.22.1.tar.gz</URL>
+      <MD5>27269b66e4bd20d099bd84bdb191ee39</MD5>
+      <SHA256>7132d376a5cb605847022724e9a5dd294bd7c8a988e686b954fdeb00e24fe302</SHA256>
+      <FileSize>7030556</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/scikit-learn-1.0.2/install.sh
+++ b/pts/scikit-learn-1.0.2/install.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+tar xvf scikit-learn-0.22.1.tar.gz
+
+echo "#!/bin/sh
+cd scikit-learn-0.22.1/benchmarks/
+python bench_random_projections.py
+echo \$? > ~/test-exit-status" > scikit-learn
+chmod +x scikit-learn

--- a/pts/scikit-learn-1.0.2/results-definition.xml
+++ b/pts/scikit-learn-1.0.2/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m2-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/scikit-learn-1.0.2/test-definition.xml
+++ b/pts/scikit-learn-1.0.2/test-definition.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m2-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Scikit-Learn</Title>
+    <AppVersion>0.22.1</AppVersion>
+    <Description>Scikit-learn is a Python module for machine learning</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.2</Version>
+    <SupportedPlatforms>Linux, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>python-scipy, python-sklearn, python</ExternalDependencies>
+    <ProjectURL>http://scikit-learn.org/</ProjectURL>
+    <Maintainer>Victor Rodriguez</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>


### PR DESCRIPTION
The scikit-learn benchmark in current pts is 0.17.1, upgrade the benchmark package to 0.22.1