### PR TITLE
add mlpack-benchmarks for machine learning benchmarking

### DIFF
--- a/pts/mlpack-benchmarks-1.0.0/downloads.xml
+++ b/pts/mlpack-benchmarks-1.0.0/downloads.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m2-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/mlpack/benchmarks/archive/master.zip</URL>
+      <MD5>5c64e39100243ffeb0586efa6887195b</MD5>
+      <SHA256>10123cd85eff747230bcdb05e0b93254b2642d62370009ac3e461ddaef59b768</SHA256>
+      <FileSize>233570</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/mlpack-benchmarks-1.0.0/install.sh
+++ b/pts/mlpack-benchmarks-1.0.0/install.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+unzip -o master.zip
+cd benchmarks-master/
+mv datasets/dataset-urls.txt datasets/dataset-urls.txt.bk
+cat datasets/dataset-urls.txt.bk|grep "webpage" > datasets/dataset-urls.txt
+make datasets
+
+cd ../
+echo "#!/bin/sh
+cd benchmarks-master/
+case \$@ in
+        \"SCIKIT_SVM\")
+		cat test.yaml |grep -A 9 "SCIKIT_SVM" > ./SCIKIT_SVM.yaml
+		sed -i -e '/oilspill_train/d' -e 's/iris/webpage/g' SCIKIT_SVM.yaml
+        ;;
+esac
+
+python run.py -l SCIKIT -m SVM -c \$@.yaml > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status" > mlpack-benchmarks
+chmod +x mlpack-benchmarks

--- a/pts/mlpack-benchmarks-1.0.0/results-definition.xml
+++ b/pts/mlpack-benchmarks-1.0.0/results-definition.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m2-->
+<PhoronixTestSuite>
+  <ResultsParser>
+ 	<OutputTemplate>[INFO] Metric: {'runtime': #_RESULT_#, 'ACC': 0.7953248917640812, 'MCC': 0.7416568406864265, 'Precision': 0.9656353770683679, 'Recall': 0.7953248917640812, 'MSE': 0.012938842404899509}</OutputTemplate>
+	<StripFromResult>,</StripFromResult>
+  </ResultsParser>
+</PhoronixTestSuite>
+

--- a/pts/mlpack-benchmarks-1.0.0/test-definition.xml
+++ b/pts/mlpack-benchmarks-1.0.0/test-definition.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m2-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Mlpack Benchmark</Title>
+    <AppVersion>1.0.0</AppVersion>
+    <Description>Mlpack benchmark scripts for machine learning libraries</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.0</Version>
+    <SupportedPlatforms>Linux, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ProjectURL>https://github.com/mlpack/benchmarks</ProjectURL>
+    <Maintainer>Yu Ma</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Benchmark</DisplayName>
+      <Identifier>benchmark</Identifier>
+      <Menu>
+        <Entry>
+          <Name>scikit_svm</Name>
+          <Value>SCIKIT_SVM</Value>
+ 	</Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+
+
+</PhoronixTestSuite>

--- a/pts/scikit-learn-1.0.2/downloads.xml
+++ b/pts/scikit-learn-1.0.2/downloads.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m2-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/scikit-learn/scikit-learn/archive/0.22.1/scikit-learn-0.22.1.tar.gz</URL>
+      <MD5>27269b66e4bd20d099bd84bdb191ee39</MD5>
+      <SHA256>7132d376a5cb605847022724e9a5dd294bd7c8a988e686b954fdeb00e24fe302</SHA256>
+      <FileSize>7030556</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/scikit-learn-1.0.2/install.sh
+++ b/pts/scikit-learn-1.0.2/install.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+
+tar xvf scikit-learn-0.22.1.tar.gz
+
+echo "#!/bin/sh
+cd scikit-learn-0.22.1/benchmarks/
+python bench_random_projections.py
+echo \$? > ~/test-exit-status" > scikit-learn
+chmod +x scikit-learn

--- a/pts/scikit-learn-1.0.2/results-definition.xml
+++ b/pts/scikit-learn-1.0.2/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m2-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/scikit-learn-1.0.2/test-definition.xml
+++ b/pts/scikit-learn-1.0.2/test-definition.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.2.0m2-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Scikit-Learn</Title>
+    <AppVersion>0.22.1</AppVersion>
+    <Description>Scikit-learn is a Python module for machine learning</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.2</Version>
+    <SupportedPlatforms>Linux, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>python-scipy, python-sklearn, python</ExternalDependencies>
+    <ProjectURL>http://scikit-learn.org/</ProjectURL>
+    <Maintainer>Victor Rodriguez</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>


### PR DESCRIPTION
1. Upgraded pts scikit-learn-1.0.1 to scikit-learn-1.0.2 with updating scikit-learn package version from 0.17.1 to latest 0.22.1

2. Added mlpack-benchmarks to pts for machine learning benchmarking. This benchmark suite can be used for measuring and comparing the performance (of different algorithms and libraries on various datasets) with different metrics (Details at: https://github.com/mlpack/benchmarks). Current initial commit enabled benchmark for scikit-learn svm algorithm.