### PR TITLE
numpy 1.1.1: use geometric mean for final score

### DIFF
--- a/pts/numpy-1.1.1/downloads.xml
+++ b/pts/numpy-1.1.1/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://www.phoronix-test-suite.com/benchmark-files/numpy-benchmarks-20190903.tar.gz</URL>
+      <MD5>d7026b2b5aa41838eaf3c365ff676f08</MD5>
+      <SHA256>5c8600646d9d34d48cb5c3c410d877fe85626d4b85eba9f09c4426ac330e5aa2</SHA256>
+      <FileName>numpy-benchmarks-20190903.tar.gz</FileName>
+      <FileSize>15023</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/numpy-1.1.1/install.sh
+++ b/pts/numpy-1.1.1/install.sh
@@ -2,10 +2,25 @@
 
 tar -xvf numpy-benchmarks-20190903.tar.gz
 echo $? > ~/install-exit-status
+
+echo "import sys
+
+product = 1
+count = 0
+with open(sys.argv[-1]) as fp:
+    for l in fp.readlines():
+        parts = l.split()
+        avg = float(parts[3])
+        product *= avg
+        count += 1
+gmean = product**(1.0/count)
+score = 1000000.0/gmean
+print(\"Geometric mean score: %.2f\" % score)" > result_parser.py
+
+
 echo "#!/bin/sh
 cd numpy-benchmarks-master/
 python3 run.py -t python -p python3 > numpy_log
-echo \$? > ~/test-exit-status 
-echo 'Test name :   Avg time ( nanoseconds )'
-cat numpy_log > \$LOG_FILE" > numpy
+echo \$? > ~/test-exit-status
+python3 ../result_parser.py numpy_log > \$LOG_FILE" > numpy
 chmod +x numpy

--- a/pts/numpy-1.1.1/install.sh
+++ b/pts/numpy-1.1.1/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+tar -xvf numpy-benchmarks-20190903.tar.gz
+echo $? > ~/install-exit-status
+echo "#!/bin/sh
+cd numpy-benchmarks-master/
+python3 run.py -t python -p python3 > numpy_log
+echo \$? > ~/test-exit-status 
+echo 'Test name :   Avg time ( nanoseconds )'
+cat numpy_log > \$LOG_FILE" > numpy
+chmod +x numpy

--- a/pts/numpy-1.1.1/results-definition.xml
+++ b/pts/numpy-1.1.1/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.1-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/numpy-1.1.1/results-definition.xml
+++ b/pts/numpy-1.1.1/results-definition.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <!--Phoronix Test Suite v9.2.1-->
 <PhoronixTestSuite>
-  <SystemMonitor>
-    <Sensor>sys.time</Sensor>
-  </SystemMonitor>
+  <ResultsParser>
+    <OutputTemplate>Geometric mean score: #_RESULT_#</OutputTemplate>
+    <ResultPrecision>2</ResultPrecision>
+  </ResultsParser>
 </PhoronixTestSuite>

--- a/pts/numpy-1.1.1/test-definition.xml
+++ b/pts/numpy-1.1.1/test-definition.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Numpy Benchmark</Title>
+    <Description>This is a test to obtain the general Numpy performance.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.0</Version>
+    <SupportedPlatforms>Linux, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>python</ExternalDependencies>
+    <EnvironmentSize>12.4</EnvironmentSize>
+    <ProjectURL>http://github.com/serge-sans-paille/</ProjectURL>
+    <Maintainer>Victor Rodriguez Bahena</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>

--- a/pts/numpy-1.1.1/test-definition.xml
+++ b/pts/numpy-1.1.1/test-definition.xml
@@ -4,12 +4,12 @@
   <TestInformation>
     <Title>Numpy Benchmark</Title>
     <Description>This is a test to obtain the general Numpy performance.</Description>
-    <ResultScale>Seconds</ResultScale>
-    <Proportion>LIB</Proportion>
+    <ResultScale>Score</ResultScale>
+    <Proportion>HIB</Proportion>
     <TimesToRun>3</TimesToRun>
   </TestInformation>
   <TestProfile>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <SupportedPlatforms>Linux, BSD</SupportedPlatforms>
     <SoftwareType>Utility</SoftwareType>
     <TestType>Processor</TestType>


### PR DESCRIPTION
use geometry mean instead of total average time, because numpy-benchmarks has many sub benchmarks, and their time vary differently, if use total time, then it will heavily count on the big number (like make_decision here):

```
make_decision:257912
multiple_sum:1282
normalize_complex_arr:207
pairwise:6175
periodic_dist:749
repeating:796
reverse_cumsum:2322
rosen:7764
slowparts:2241
specialconvolve:2601
vibr_energy:891
wave:25892
wdist:29697
````
1. use python3 instead of awk (PR#116) to avoid some compatibility issue in different OS. 
2. make result as `HIB` and unit is `Score`, use `1000000/gmean` to normalize