### PR TITLE
add more mlpack benchmarks for scikit-learn: ridge, ica, qda

### DIFF
--- a/pts/mlpack-1.0.0/install.sh
+++ b/pts/mlpack-1.0.0/install.sh
@@ -6,6 +6,7 @@ unzip -o mlpack-benchmarks-20200110.zip
 cd benchmarks-master/
 mv datasets/dataset-urls.txt datasets/dataset-urls.txt.bk
 cat datasets/dataset-urls.txt.bk|grep "webpage" > datasets/dataset-urls.txt
+cat datasets/dataset-urls.txt.bk|grep "reuters" >> datasets/dataset-urls.txt
 make datasets
 echo $? > ~/install-exit-status
 
@@ -14,10 +15,23 @@ echo "#!/bin/sh
 cd benchmarks-master/
 case \$@ in
         \"SCIKIT_SVM\")
-		cat test.yaml |grep -A 9 \"SCIKIT_SVM\" > ./SCIKIT_SVM.yaml
-		sed -i -e '/oilspill_train/d' -e 's/iris/webpage/g' SCIKIT_SVM.yaml
+                cat test.yaml |grep -A 9 \"\$@\" > ./\$@.yaml
+                sed -i -e '/oilspill_train/d' -e 's/iris/webpage/g' \$@.yaml
         ;;
+        \"SCIKIT_LINEARRIDGEREGRESSION\")
+                cat test.yaml |grep -A 9 \"\$@\" > ./\$@.yaml
+                sed -i -e 's/sickEuthyroid/reuters/g' \$@.yaml
+        ;;
+        \"SCIKIT_QDA\")
+                cat test.yaml |grep -A 9 \"\$@\" > ./\$@.yaml
+                sed -i -e '/oilspill/d' -e 's/iris/reuters/g' \$@.yaml
+        ;;
+        \"SCIKIT_ICA\")
+                cat test.yaml |grep -A 9 \"\$@\" > ./\$@.yaml
+                sed -i -e '/wine/d' -e 's/iris/webpage_train/g' \$@.yaml
+        ;;
+
 esac
-python3 run.py -l SCIKIT -m SVM -c \$@.yaml > \$LOG_FILE 2>&1
+python3 run.py -c \$@.yaml > \$LOG_FILE 2>&1
 echo \$? > ~/test-exit-status" > mlpack
 chmod +x mlpack

--- a/pts/mlpack-1.0.0/results-definition.xml
+++ b/pts/mlpack-1.0.0/results-definition.xml
@@ -3,6 +3,22 @@
 <PhoronixTestSuite>
   <ResultsParser>
     <OutputTemplate>[INFO] Metric: {'runtime': #_RESULT_#, 'ACC': 0.7953248917640812, 'MCC': 0.7416568406864265, 'Precision': 0.9656353770683679, 'Recall': 0.7953248917640812, 'MSE': 0.012938842404899509}</OutputTemplate>
+    <MatchToTestArguments>SCIKIT_SVM</MatchToTestArguments>
     <StripFromResult>,</StripFromResult>
+  </ResultsParser>
+  <ResultsParser>
+	<OutputTemplate>[INFO] Metric: {'runtime': #_RESULT_#, 'MSE': 0.0099063666127401}</OutputTemplate>
+	<MatchToTestArguments>SCIKIT_LINEARRIDGEREGRESSION</MatchToTestArguments>
+    <StripFromResult>,</StripFromResult>
+  </ResultsParser>
+  <ResultsParser>
+	<OutputTemplate>[INFO] Metric: {'runtime': #_RESULT_#, 'ACC': 0.5287654814222933, 'MCC': 0.036204581617472295, 'Precision': 0.5113918806959403, 'Recall': 0.5287654814222933, 'MSE': 0.9222048475371384}</OutputTemplate>
+	<MatchToTestArguments>SCIKIT_QDA</MatchToTestArguments>
+    <StripFromResult>,</StripFromResult>
+  </ResultsParser>
+ <ResultsParser>
+	 <OutputTemplate>[INFO] Metric: {'runtime': #_RESULT_#}</OutputTemplate>
+	<MatchToTestArguments>SCIKIT_ICA</MatchToTestArguments>
+	<StripFromResult>}</StripFromResult>
   </ResultsParser>
 </PhoronixTestSuite>

--- a/pts/mlpack-1.0.0/test-definition.xml
+++ b/pts/mlpack-1.0.0/test-definition.xml
@@ -28,6 +28,19 @@
           <Name>scikit_svm</Name>
           <Value>SCIKIT_SVM</Value>
         </Entry>
+	<Entry>
+	  <Name>scikit_linearridgeregression</Name>
+	  <Value>SCIKIT_LINEARRIDGEREGRESSION</Value>
+        </Entry>
+	<Entry>
+	  <Name>scikit_qda</Name>
+	  <Value>SCIKIT_QDA</Value>
+        </Entry>
+	<Entry>
+	  <Name>scikit_ica</Name>
+	  <Value>SCIKIT_ICA</Value>
+        </Entry>
+
       </Menu>
     </Option>
   </TestSettings>


### PR DESCRIPTION
This PR is to add 3 more indicators in mlpack to benchmark below 3 scikit-learn algorithms respectively:
1. linear ridge regression
2. QuadraticDiscriminantAnalysis
3. FastICA