### PR TITLE
keydb-1.1.0: use Memtier to benchmark KeyDB

### DIFF
--- a/pts/keydb-1.1.0/downloads.xml
+++ b/pts/keydb-1.1.0/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/JohnSully/KeyDB/archive/v5.0.2.tar.gz</URL>
+      <MD5>a65ee0695716d5ff5f65acc69d2a0855</MD5>
+      <SHA256>3457075153a9c588caaf22d3e7d7fd214c56c60c19401a2d1fe8c46ca30d98bf</SHA256>
+      <FileName>KeyDB-5.0.2.tar.gz</FileName>
+      <FileSize>3016462</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/keydb-1.1.0/downloads.xml
+++ b/pts/keydb-1.1.0/downloads.xml
@@ -9,5 +9,12 @@
       <FileName>KeyDB-5.0.2.tar.gz</FileName>
       <FileSize>3016462</FileSize>
     </Package>
+    <Package>
+      <URL>https://github.com/RedisLabs/memtier_benchmark/archive/1.2.17.tar.gz</URL>
+      <MD5>08b45090c273ba1c32a174f02a55dfd6</MD5>
+      <SHA256>18526a32732173ac5f73cecfa003571079634e8d124132eaf545c46bab61e0b2</SHA256>
+      <FileName>memtier_benchmark-1.2.17.tar.gz</FileName>
+      <FileSize>76872</FileSize>
+    </Package>
   </Downloads>
 </PhoronixTestSuite>

--- a/pts/keydb-1.1.0/install.sh
+++ b/pts/keydb-1.1.0/install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+tar -xzf KeyDB-5.0.2.tar.gz
+
+cd ~/KeyDB-5.0.2/deps
+make hiredis jemalloc linenoise lua
+
+cd ~/KeyDB-5.0.2
+make MALLOC=libc -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+
+cd ~
+echo "#!/bin/sh
+cd ~/KeyDB-5.0.2/
+
+./src/keydb-server --server-threads 4 &
+KEYDB_SERVER_PID=\$!
+sleep 8
+
+./src/keydb-benchmark --threads \$NUM_CPU_CORES \$@ > \$LOG_FILE
+kill \$KEYDB_SERVER_PID
+sleep 2" > keydb
+chmod +x keydb

--- a/pts/keydb-1.1.0/install.sh
+++ b/pts/keydb-1.1.0/install.sh
@@ -10,6 +10,14 @@ make MALLOC=libc -j $NUM_CPU_CORES
 echo $? > ~/install-exit-status
 
 cd ~
+tar -xf memtier_benchmark-1.2.17.tar.gz
+cd memtier_benchmark-1.2.17/
+autoreconf -ivf
+./configure
+make -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+
+cd ~
 echo "#!/bin/sh
 cd ~/KeyDB-5.0.2/
 
@@ -17,7 +25,9 @@ cd ~/KeyDB-5.0.2/
 KEYDB_SERVER_PID=\$!
 sleep 8
 
-./src/keydb-benchmark --threads \$NUM_CPU_CORES \$@ > \$LOG_FILE
+cd ~/memtier_benchmark-1.2.17/
+./memtier_benchmark --hide-histogram -t \$NUM_CPU_CORES \$@ > \$LOG_FILE
+
 kill \$KEYDB_SERVER_PID
 sleep 2" > keydb
 chmod +x keydb

--- a/pts/keydb-1.1.0/results-definition.xml
+++ b/pts/keydb-1.1.0/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>#_RESULT_# requests per second</OutputTemplate>
+    <LineHint>requests per second</LineHint>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/keydb-1.1.0/results-definition.xml
+++ b/pts/keydb-1.1.0/results-definition.xml
@@ -2,7 +2,7 @@
 <!--Phoronix Test Suite v9.0.1-->
 <PhoronixTestSuite>
   <ResultsParser>
-    <OutputTemplate>#_RESULT_# requests per second</OutputTemplate>
-    <LineHint>requests per second</LineHint>
+    <OutputTemplate>Totals     #_RESULT_#     13833.49     36766.29     63.52700      6330.95 </OutputTemplate>
+    <LineHint>Totals</LineHint>
   </ResultsParser>
 </PhoronixTestSuite>

--- a/pts/keydb-1.1.0/test-definition.xml
+++ b/pts/keydb-1.1.0/test-definition.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>KeyDB</Title>
+    <AppVersion>5.0.2</AppVersion>
+    <Description>A benchmark of KeyDB as a multi-threaded fork of the Redis server.</Description>
+    <ResultScale>Requests Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.1</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, libevent, pcre, openssl-development, libtool, curl, uuid</ExternalDependencies>
+    <EnvironmentSize>69</EnvironmentSize>
+    <ProjectURL>https://github.com/JohnSully/KeyDB</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments>-n 250000</Arguments>
+    </Default>
+  </TestSettings>
+</PhoronixTestSuite>

--- a/pts/keydb-1.1.0/test-definition.xml
+++ b/pts/keydb-1.1.0/test-definition.xml
@@ -5,7 +5,7 @@
     <Title>KeyDB</Title>
     <AppVersion>5.0.2</AppVersion>
     <Description>A benchmark of KeyDB as a multi-threaded fork of the Redis server.</Description>
-    <ResultScale>Requests Per Second</ResultScale>
+    <ResultScale>Ops/sec</ResultScale>
     <Proportion>HIB</Proportion>
     <TimesToRun>3</TimesToRun>
   </TestInformation>

--- a/pts/keydb-1.1.0/test-definition.xml
+++ b/pts/keydb-1.1.0/test-definition.xml
@@ -10,7 +10,7 @@
     <TimesToRun>3</TimesToRun>
   </TestInformation>
   <TestProfile>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <SupportedPlatforms>Linux</SupportedPlatforms>
     <SoftwareType>Benchmark</SoftwareType>
     <TestType>System</TestType>

--- a/pts/keydb-1.1.0/test-definition.xml
+++ b/pts/keydb-1.1.0/test-definition.xml
@@ -23,7 +23,7 @@
   </TestProfile>
   <TestSettings>
     <Default>
-      <Arguments>-n 250000</Arguments>
+      <Arguments>--test-time 60</Arguments>
     </Default>
   </TestSettings>
 </PhoronixTestSuite>


### PR DESCRIPTION
1. By far, the document of KeyDB only use `memtier` for benchmarking: https://docs.keydb.dev/docs/benchmarking/

2. KeyDB maintainer recommends `memtier` for benchmark, `keydb-benchmark` is still not suitable for multi-thread testing, refer to https://github.com/JohnSully/KeyDB/issues/145

