### PR TITLE
add one more indicator in scikit-learn for sgd regression

### DIFF
--- a/pts/scikit-learn-1.1.1/downloads.xml
+++ b/pts/scikit-learn-1.1.1/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/scikit-learn/scikit-learn/archive/0.22.1/scikit-learn-0.22.1.tar.gz</URL>
+      <MD5>27269b66e4bd20d099bd84bdb191ee39</MD5>
+      <SHA256>7132d376a5cb605847022724e9a5dd294bd7c8a988e686b954fdeb00e24fe302</SHA256>
+      <FileName>scikit-learn-0.22.1.tar.gz</FileName>
+      <FileSize>7030556</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/scikit-learn-1.1.1/install.sh
+++ b/pts/scikit-learn-1.1.1/install.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+tar xvf scikit-learn-0.22.1.tar.gz
+
+echo "#!/bin/sh
+cd scikit-learn-0.22.1/benchmarks/
+
+cat <<'EOF' > insert_sgd_regression
+
+    elnet_time = elnet_results.sum(axis=(0,1))[1]
+    sgd_time = sgd_results.sum(axis=(0,1))[1]
+    asgd_time = asgd_results.sum(axis=(0,1))[1]
+    ridge_time = ridge_results.sum(axis=(0,1))[1]
+    total_time = elnet_time + sgd_time + asgd_time + ridge_time
+    print(\"Final result: %fs\" % total_time)
+
+EOF
+
+
+
+case \$@ in
+        \"RANDOM_PROJECTIONS\")
+		time -p python3 bench_random_projections.py > \$LOG_FILE 2>&1
+        ;;
+        \"SGD_REGRESSION\")
+                sed -i -e '5 s/^/\#/' -e '112, $ s/^/\#/' -e '110r insert_sgd_regression' bench_sgd_regression.py
+		rm insert_sgd_regression
+                python3 bench_sgd_regression.py > \$LOG_FILE 2>&1
+        ;;
+
+esac
+echo \$? > ~/test-exit-status" > scikit-learn
+chmod +x scikit-learn
+

--- a/pts/scikit-learn-1.1.1/results-definition.xml
+++ b/pts/scikit-learn-1.1.1/results-definition.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>real #_RESULT_#</OutputTemplate>
+    <MatchToTestArguments>RANDOM_PROJECTIONS</MatchToTestArguments>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>Final result: #_RESULT_#s</OutputTemplate>
+    <MatchToTestArguments>SGD_REGRESSION</MatchToTestArguments>
+    <StripFromResult>s</StripFromResult>
+  </ResultsParser>
+
+</PhoronixTestSuite>

--- a/pts/scikit-learn-1.1.1/test-definition.xml
+++ b/pts/scikit-learn-1.1.1/test-definition.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.2.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Scikit-Learn</Title>
+    <AppVersion>0.22.1</AppVersion>
+    <Description>Scikit-learn is a Python module for machine learning</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.1</Version>
+    <SupportedPlatforms>Linux, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>python-scipy, python-sklearn, python</ExternalDependencies>
+    <ProjectURL>http://scikit-learn.org/</ProjectURL>
+    <Maintainer>Victor Rodriguez</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Benchmark</DisplayName>
+      <Identifier>benchmark</Identifier>
+      <Menu>
+        <Entry>
+          <Name>random_projections</Name>
+          <Value>RANDOM_PROJECTIONS</Value>
+        </Entry>
+        <Entry>
+          <Name>sgd_regression</Name>
+          <Value>SGD_REGRESSION</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+
+</PhoronixTestSuite>


### PR DESCRIPTION
ATT, and bump scikit-learn to 1.1.1.

BTW, the original result_definition.xml for random_projection in scikit-1.1.0 is to use sys.monitor time.

However, i found that after added the new indicator in result_definition.xml, the sys.monitor cannot get result, so i revised install.sh to run this indicator with "time -p python3 bench_random_projections.py" to get the final result. Please kindly let me know if there is a neat way to let sys.monitor workable in results_definition.xml when there is multiple indicators. Thanks a lot :)