### PR TITLE
Add pts/build-gcc-1.2.0 which updates gcc source code from 8.2.0 to 8.4.0.

### DIFF
--- a/pts/build-gcc-1.2.0/downloads.xml
+++ b/pts/build-gcc-1.2.0/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.8.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>ftp://ftp.fu-berlin.de/unix/languages/gcc/releases/gcc-8.4.0/gcc-8.4.0.tar.gz, ftp://ftp.gwdg.de/pub/misc/gcc/releases/gcc-8.4.0/gcc-8.4.0.tar.gz, https://ftp.gnu.org/gnu/gcc/gcc-8.4.0/gcc-8.4.0.tar.gz</URL>
+      <MD5>732a4fd69c36c0a12ee2b43368ccf3c9</MD5>
+      <SHA256>41e8b145832fc0b2b34c798ed25fb54a881b0cee4cd581b77c7dc92722c116a8</SHA256>
+      <FileName>gcc-8.4.0.tar.gz</FileName>
+      <FileSize>114232712</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/build-gcc-1.2.0/install.sh
+++ b/pts/build-gcc-1.2.0/install.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "#!/bin/sh
+
+cd gcc-8.4.0
+make -s -j \$NUM_CPU_CORES 2>&1
+echo \$? > ~/test-exit-status" > build-gcc
+
+chmod +x build-gcc

--- a/pts/build-gcc-1.2.0/interim.sh
+++ b/pts/build-gcc-1.2.0/interim.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+cd gcc-8.4.0
+make distclean
+./contrib/download_prerequisites
+./configure --disable-multilib --enable-checking=release

--- a/pts/build-gcc-1.2.0/post.sh
+++ b/pts/build-gcc-1.2.0/post.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -rf gcc-8.4.0

--- a/pts/build-gcc-1.2.0/pre.sh
+++ b/pts/build-gcc-1.2.0/pre.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+rm -rf gcc-8.4.0
+tar -xf gcc-8.4.0.tar.gz
+
+cd gcc-8.4.0
+./contrib/download_prerequisites
+./configure --disable-multilib --enable-checking=release
+make defconfig
+make clean

--- a/pts/build-gcc-1.2.0/results-definition.xml
+++ b/pts/build-gcc-1.2.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.8.1-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/build-gcc-1.2.0/test-definition.xml
+++ b/pts/build-gcc-1.2.0/test-definition.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v8.8.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Timed GCC Compilation</Title>
+    <AppVersion>8.4</AppVersion>
+    <Description>This test times how long it takes to build the GNU Compiler Collection (GCC).</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <SubTitle>Time To Compile</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.2.0</Version>
+    <SupportedPlatforms>Linux, BSD, macOS</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, bison, flex, gmp-library</ExternalDependencies>
+    <ProjectURL>https://gcc.gnu.org/</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>


### PR DESCRIPTION
pts/build-gcc-1.1.2 uses gcc 8.2.0 which will fail to be compiled under glibc 2.31. I reported it to gcc upstream (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94139), they recommend to use gcc 8.4.0 as they don't fix any bugs for those released versions. I tried building gcc 8.4.0 under glibc 2.31 and it could be completed successfully.