### PR TITLE
Fix for errors in parsing of HTTP results

### DIFF
--- a/pts/ethr-1.0.4/results-definition.xml
+++ b/pts/ethr-1.0.4/results-definition.xml
@@ -33,15 +33,15 @@
     <ResultProportion>LIB</ResultProportion>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate>  HTTP     008-009 sec   #_RESULT_#</OutputTemplate>
-    <LineHint>HTTP</LineHint>
+    <OutputTemplate>  HTTP     008-009 sec   #_RESULT_#M</OutputTemplate>
+    <LineHint>M</LineHint>
     <StripFromResult>M</StripFromResult>
     <MultiMatch>AVERAGE</MultiMatch>
     <ResultScale>Mbits/sec</ResultScale>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate>  HTTP     008-009 sec   #_RESULT_#</OutputTemplate>
-    <LineHint>HTTP</LineHint>
+    <OutputTemplate>  HTTP     008-009 sec   #_RESULT_#G</OutputTemplate>
+    <LineHint>G</LineHint>
     <StripFromResult>G</StripFromResult>
     <MultiMatch>AVERAGE</MultiMatch>
     <MultiplyResultBy>1000</MultiplyResultBy>


### PR DESCRIPTION
HTTP results are being incorrectly filtered by GB/s and MB/s
resulting in double parsing, with invalid multiplication and resultant averages.

Eg, the parsing of a results file containing:

- - - - - - - - - - - - - - - - - - - - - - -
Protocol    Interval      Bits/s
  HTTP     000-001 sec   511.87M
  HTTP     001-002 sec   626.30M
  HTTP     002-003 sec   609.79M
  HTTP     003-004 sec   564.10M
  HTTP     004-005 sec   636.93M
  HTTP     005-006 sec   505.86M
  HTTP     006-007 sec   620.80M
  HTTP     007-008 sec   628.48M
  HTTP     008-009 sec   641.54M
  HTTP     009-010 sec   642.94M
  HTTP     010-011 sec   643.07M
  HTTP     011-012 sec   594.05M
  HTTP     012-013 sec   643.46M
  HTTP     013-014 sec   647.81M
  HTTP     014-015 sec   585.34M
  HTTP     015-016 sec   576.77M
  HTTP     016-017 sec   639.62M
  HTTP     017-018 sec   551.04M
  HTTP     018-019 sec   606.72M
  HTTP     019-020 sec   610.56M
Ethr done, duration: 20s.

Is reported as follows:
Test Result Parser Returning: 641540000000


Log File At: /var/lib/phoronix-test-suite/installed-tests/pts/ethr-1.0.4/ethr-1.0.4-1591796995-1.log


##########################################################################
Ethr:
Server Address: 10.0.0.251 - Protocol: HTTP - Test: Bandwidth - Threads: 2

641.54 Mbits/sec
641540000000 Mbits/sec

Average: 320770000320.77 Mbits/sec
##########################################################################