### PR TITLE
pts/ncnn-1.0.x: Skip tools and examples build gracefully with cmake option

### DIFF
--- a/pts/ncnn-1.0.0/install.sh
+++ b/pts/ncnn-1.0.0/install.sh
@@ -3,25 +3,11 @@
 tar -xf ncnn-20200916.tar.gz
 cd ncnn-20200916
 
-# Workaround for build issues with current release
-echo "cmake_minimum_required(VERSION 3.1) # for CMAKE_CXX_STANDARD
-set(CMAKE_CXX_STANDARD 11)
-
-add_subdirectory(caffe)
-add_subdirectory(mxnet)
-add_subdirectory(onnx)
-add_subdirectory(darknet)
-add_subdirectory(quantize)
-" > tools/CMakeLists.txt
-
-echo "" > tools/caffe/CMakeLists.txt
-echo "" > tools/onnx/CMakeLists.txt
-
 mkdir build
 cd build
 
 # Vulkan build currently not enabled due to hitting seg fault...
-cmake ..
+cmake -DNCNN_BUILD_TOOLS=OFF -DNCNN_BUILD_EXAMPLES=OFF ..
 make -j $NUM_CPU_CORES
 # sometimes parallel build seems to fail, so do another make in case
 make

--- a/pts/ncnn-1.0.0/test-definition.xml
+++ b/pts/ncnn-1.0.0/test-definition.xml
@@ -16,7 +16,7 @@
     <TestType>System</TestType>
     <License>Free</License>
     <Status>Verified</Status>
-    <ExternalDependencies>cmake, build-utilities, protobuf, opencv</ExternalDependencies>
+    <ExternalDependencies>cmake, build-utilities</ExternalDependencies>
     <EnvironmentSize>2700</EnvironmentSize>
     <ProjectURL>https://github.com/Tencent/ncnn</ProjectURL>
     <Maintainer>Michael Larabel</Maintainer>

--- a/pts/ncnn-1.0.1/install.sh
+++ b/pts/ncnn-1.0.1/install.sh
@@ -3,25 +3,11 @@
 tar -xf ncnn-20200916.tar.gz
 cd ncnn-20200916
 
-# Workaround for build issues with current release
-echo "cmake_minimum_required(VERSION 3.1) # for CMAKE_CXX_STANDARD
-set(CMAKE_CXX_STANDARD 11)
-
-add_subdirectory(caffe)
-add_subdirectory(mxnet)
-add_subdirectory(onnx)
-add_subdirectory(darknet)
-add_subdirectory(quantize)
-" > tools/CMakeLists.txt
-
-echo "" > tools/caffe/CMakeLists.txt
-echo "" > tools/onnx/CMakeLists.txt
-
 mkdir build
 cd build
 
 # Vulkan build currently not enabled due to hitting seg fault...
-cmake ..
+cmake -DNCNN_BUILD_TOOLS=OFF -DNCNN_BUILD_EXAMPLES=OFF ..
 make -j $NUM_CPU_CORES
 # sometimes parallel build seems to fail, so do another make in case
 make

--- a/pts/ncnn-1.0.1/test-definition.xml
+++ b/pts/ncnn-1.0.1/test-definition.xml
@@ -16,7 +16,7 @@
     <TestType>System</TestType>
     <License>Free</License>
     <Status>Verified</Status>
-    <ExternalDependencies>cmake, build-utilities, protobuf, opencv</ExternalDependencies>
+    <ExternalDependencies>cmake, build-utilities</ExternalDependencies>
     <EnvironmentSize>2700</EnvironmentSize>
     <ProjectURL>https://github.com/Tencent/ncnn</ProjectURL>
     <Maintainer>Michael Larabel</Maintainer>


### PR DESCRIPTION
no more source hack
and no more protobuf opencv dependency