### PR TITLE
pts/ncnn-1.0.2: enable vulkan

### DIFF
--- a/pts/ncnn-1.0.2/downloads.xml
+++ b/pts/ncnn-1.0.2/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.0.0m2-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/Tencent/ncnn/archive/20200916.tar.gz</URL>
+      <MD5>d93c0b057066540f52bae858701f8ee0</MD5>
+      <SHA256>a7abc03c9acdaa1b4f85ce3f80722822f9eacc0efefc9dfef1e253fdb23d0f80</SHA256>
+      <FileName>ncnn-20200916.tar.gz</FileName>
+      <FileSize>11121685</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/ncnn-1.0.2/install.sh
+++ b/pts/ncnn-1.0.2/install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+tar -xf ncnn-20200916.tar.gz
+cd ncnn-20200916
+
+mkdir build
+cd build
+
+cmake -DNCNN_VULKAN=ON -DNCNN_BUILD_TOOLS=OFF -DNCNN_BUILD_EXAMPLES=OFF ..
+make -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+
+cp ../benchmark/*.param benchmark/
+
+cd ~/
+cat>ncnn<<EOT
+#!/bin/sh
+cd ncnn-20200916/build/benchmark
+./benchncnn 200 \$NUM_CPU_CORES 0 \$@ 0  > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status
+EOT
+chmod +x ncnn
+

--- a/pts/ncnn-1.0.2/install.sh
+++ b/pts/ncnn-1.0.2/install.sh
@@ -7,6 +7,11 @@ mkdir build
 cd build
 
 cmake -DNCNN_VULKAN=ON -DNCNN_BUILD_TOOLS=OFF -DNCNN_BUILD_EXAMPLES=OFF ..
+# try to build cpu-only test on system without vulkan development files
+is_cmake_ok=$?
+if [ $is_cmake_ok -ne 0 ]; then
+    cmake -DNCNN_VULKAN=OFF -DNCNN_BUILD_TOOLS=OFF -DNCNN_BUILD_EXAMPLES=OFF ..
+fi
 make -j $NUM_CPU_CORES
 echo $? > ~/install-exit-status
 

--- a/pts/ncnn-1.0.2/results-definition.xml
+++ b/pts/ncnn-1.0.2/results-definition.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.0.0m2-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>          squeezenet  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>          squeezenet  </LineHint>
+    <AppendToArgumentsDescription>Model: squeezenet</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>           mobilenet  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>           mobilenet  </LineHint>
+    <AppendToArgumentsDescription>Model: mobilenet</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>        mobilenet_v2  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>        mobilenet_v2  </LineHint>
+    <AppendToArgumentsDescription>Model: mobilenet-v2</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>        mobilenet_v3  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>        mobilenet_v3  </LineHint>
+    <AppendToArgumentsDescription>Model: mobilenet-v3</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>       shufflenet_v2  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>       shufflenet_v2  </LineHint>
+    <AppendToArgumentsDescription>Model: shufflenet-v2</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>             mnasnet  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>             mnasnet  </LineHint>
+    <AppendToArgumentsDescription>Model: mnasnet</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>     efficientnet_b0  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>     efficientnet_b0  </LineHint>
+    <AppendToArgumentsDescription>Model: efficientnet-b0</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>           blazeface  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>           blazeface  </LineHint>
+    <AppendToArgumentsDescription>Model: blazeface</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>           googlenet  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>           googlenet  </LineHint>
+    <AppendToArgumentsDescription>Model: googlenet</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>               vgg16  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>               vgg16  </LineHint>
+    <AppendToArgumentsDescription>Model: vgg16</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>            resnet18  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>            resnet18  </LineHint>
+    <AppendToArgumentsDescription>Model: resnet18</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>             alexnet  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>             alexnet  </LineHint>
+    <AppendToArgumentsDescription>Model: alexnet</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>            resnet50  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>            resnet50  </LineHint>
+    <AppendToArgumentsDescription>Model: resnet50</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>  mobilenetv2_yolov3  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>  mobilenetv2_yolov3  </LineHint>
+    <AppendToArgumentsDescription>Model: mobilenetv2-yolov3</AppendToArgumentsDescription>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>         yolov4-tiny  min =    #_MIN_RESULT_#  max =   #_MAX_RESULT_#  avg =    #_RESULT_#</OutputTemplate>
+    <LineHint>         yolov4-tiny  </LineHint>
+    <AppendToArgumentsDescription>Model: yolov4-tiny</AppendToArgumentsDescription>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/ncnn-1.0.2/test-definition.xml
+++ b/pts/ncnn-1.0.2/test-definition.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.0.0m2-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>ncnn</Title>
+    <AppVersion>20200916</AppVersion>
+    <Description>ncnn is a high performance neural network inference framework optimized for mobile and other platforms developed by Tencent.</Description>
+    <ResultScale>ms</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.2</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Scientific</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>cmake, build-utilities, vulkan-development</ExternalDependencies>
+    <EnvironmentSize>1000</EnvironmentSize>
+    <ProjectURL>https://github.com/Tencent/ncnn</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Target</DisplayName>
+      <Identifier>target</Identifier>
+      <DefaultEntry>0</DefaultEntry>
+      <Menu>
+        <Entry>
+          <Name>CPU</Name>
+          <Value>-1</Value>
+        </Entry>
+        <Entry>
+          <Name>GPU</Name>
+          <Value>0</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
skip tools and examples build gracefully with cmake option
enable vulkan build
remove int8 model test because int8 inference is not fully optimized and benchmark-ready
use lowercase ncnn