### PR TITLE
Fix for Python 3.7

### DIFF
--- a/pts/glmark2-1.1.0/install.sh
+++ b/pts/glmark2-1.1.0/install.sh
@@ -3,6 +3,13 @@
 tar -zxvf glmark2-20170617.tar.gz
 cd glmark2-20170617
 
+#Fix for python 3.7 and up
+if [[ $(python --version | grep '[0-9]\.[0-9]' -o | tr -d '.' ) -ge 37 ]]
+then
+        sed -i "/StopIteration/d" ./waflib/Node.py
+        sed -i "/StopIteration/d" ./waflib/Tools/qt5.py
+fi
+
 ./waf configure --with-flavors=x11-gl --prefix=$HOME
 ./waf build
 ./waf install


### PR DESCRIPTION
Python 3.7 and up uses [new syntax](https://www.python.org/dev/peps/pep-0479/) which breaks installation of glmark2-1.1.0 which is a part of desktop-graphics suite.
This code checks Python version and applies [necessary patches](https://github.com/glmark2/glmark2/commit/eaa70888862f63da853f8ed9c94442b7a32d3335).