### PR TITLE
Fix mysqlslap-1.1.0 test profile when run as root.

### DIFF
--- a/pts/mysqlslap-1.1.0/pre.sh
+++ b/pts/mysqlslap-1.1.0/pre.sh
@@ -3,7 +3,7 @@
 # START SERVER
 cd $HOME/mysql_
 if [ "$(whoami)" == "root" ] ; then
-    $HOME/mysql_/bin/mysqld_safe --user=root --no-defaults --datadir=$HOME/mysql_/.data &
+    $HOME/mysql_/bin/mysqld_safe --no-defaults --user=root --datadir=$HOME/mysql_/.data &
 else
     $HOME/mysql_/bin/mysqld_safe --no-defaults --datadir=$HOME/mysql_/.data &
 fi


### PR DESCRIPTION
`--no-defaults` must be the first command line option. Otherwise the database will fail to start.

Console output when running the test profile `mysqlslap-1.1.0` with the `debug-benchmark` command as root (PTS v10.2.2):

```
<...>
Running Pre-Test Script
210410 21:40:51 mysqld_safe Logging to '/var/lib/phoronix-test-suite/installed-tests/pts/mysqlslap-1.1.0//mysql_/.data/v220210473324149213.err'.
210410 21:40:51 mysqld_safe Starting mysqld daemon with databases from /var/lib/phoronix-test-suite/installed-tests/pts/mysqlslap-1.1.0//mysql_/.data
/var/lib/phoronix-test-suite/installed-tests/pts/mysqlslap-1.1.0//mysql_/bin/mysqladmin: connect to server at 'localhost' failed
error: 'Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)'
Check that mysqld is running and that the socket: '/tmp/mysql.sock' exists!
ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)
<...>
```

Further references:

* [confusing messages with --no-defaults not being first option](https://bugs.mysql.com/bug.php?id=30994)
* [--no-defaults option for mysqldump not documented](https://bugs.mysql.com/bug.php?id=83386)