### PR TITLE
pts/yquake2-1.0.2: Fix downloads list

### DIFF
--- a/pts/yquake2-1.0.2/downloads.xml
+++ b/pts/yquake2-1.0.2/downloads.xml
@@ -8,6 +8,7 @@
       <SHA256>fcc2004796908db07b69c2f9a3a829acf6e38551799f7768ccae77f66ea8e356</SHA256>
       <FileName>QUAKE2_7_45.zip</FileName>
       <FileSize>2588621</FileSize>
+       <PlatformSpecific>Linux</PlatformSpecific>
     </Package>
     <Package>
       <URL>https://master.dl.sourceforge.net/project/dcquake/quake2/demo/q2-314-demo-x86.exe, https://deponie.yamagi.org/quake2/idstuff/q2-314-demo-x86.exe</URL>
@@ -15,7 +16,6 @@
       <SHA256>7ace5a43983f10d6bdc9d9b6e17a1032ba6223118d389bd170df89b945a04a1e</SHA256>
       <FileName>q2-314-demo-x86.exe</FileName>
       <FileSize>39015499</FileSize>
-      <PlatformSpecific>Windows</PlatformSpecific>
     </Package>
     <Package>
       <URL>https://deponie.yamagi.org/quake2/windows/quake2-7.45a.zip</URL>
@@ -23,6 +23,7 @@
       <SHA256>f536888bb408ee7340b511adcfa769ef023990b9ccf93cbac51ba2198d119d43</SHA256>
       <FileName>quake2-7.45a.zip</FileName>
       <FileSize>5415592</FileSize>
+      <PlatformSpecific>Windows</PlatformSpecific>
     </Package>
   </Downloads>
 </PhoronixTestSuite>


### PR DESCRIPTION
quake2-7.45a.zip - contains windows executables
q2-314-demo-x86.exe - contains game assets
QUAKE2_7_45.zip - contains game source