### PR TITLE
srsran: update 4G PHY DL tests and add 5G NR DL tests

### DIFF
--- a/pts/srsran-1.0.0/test-definition.xml
+++ b/pts/srsran-1.0.0/test-definition.xml
@@ -29,12 +29,32 @@
       <Identifier>test</Identifier>
       <Menu>
         <Entry>
-          <Name>OFDM_Test</Name>
-          <Value>lib/src/phy/dft/test/ofdm_test -N 2048 -n 100 -r 500000</Value>
+          <Name>4G: PHY_DL_Test 100 PRB SISO 64-QAM</Name>
+          <Value>lib/test/phy/phy_dl_test -p 100 -s 20000 -m 28 -t 1</Value>
         </Entry>
         <Entry>
-          <Name>PHY_DL_Test</Name>
-          <Value>lib/test/phy/phy_dl_test -p 100 -s 20000 -m 28</Value>
+          <Name>4G: PHY_DL_Test 100 PRB SISO 256-QAM</Name>
+          <Value>lib/test/phy/phy_dl_test -p 100 -s 20000 -m 27 -t 1 -q</Value>
+        </Entry>
+        <Entry>
+          <Name>4G: PHY_DL_Test 100 PRB MIMO 64-QAM</Name>
+          <Value>lib/test/phy/phy_dl_test -p 100 -s 20000 -m 28 -t 4</Value>
+        </Entry>
+        <Entry>
+          <Name>4G: PHY_DL_Test 100 PRB MIMO 256-QAM</Name>
+          <Value>lib/test/phy/phy_dl_test -p 100 -s 20000 -m 27 -t 4 -q</Value>
+        </Entry>
+        <Entry>
+          <Name>5G: PHY_DL_NR Test 52 PRB SISO 64-QAM</Name>
+          <Value>lib/test/phy/phy_dl_nr_test -P 52 -p 52 -m 28 -n 20000</Value>
+        </Entry>
+        <Entry>
+          <Name>5G: PHY_DL_NR Test 270 PRB SISO 256-QAM</Name>
+          <Value>lib/test/phy/phy_dl_nr_test -P 270 -p 270 -m 27 -T 256qam -d 1 1 -n 20000</Value>
+        </Entry>
+        <Entry>
+          <Name>OFDM_Test</Name>
+          <Value>lib/src/phy/dft/test/ofdm_test -N 2048 -n 100 -r 500000</Value>
         </Entry>
       </Menu>
     </Option>


### PR DESCRIPTION
Hey,

thanks for updating the openbenchmark site with the new srsRAN release. I took the chance to update the test definition to include some more configs:
* few more PHY DL tests, especially MIMO modes and QAM-256
* add two new NR tests that ue the phy_dl_nr_test executable

Note that the commit does not update the result definitions file yet. In its current form it would be a lot of error-prone copy paste as the required target numbers are different for every test config. Is there a way to make that easier for you to parse?

Thanks
Andre