### PR TITLE
git/svt-av1: add 2.3.0 with gitlab link

### DIFF
--- a/git/svt-av1-2.3.0/downloads.xml
+++ b/git/svt-av1-2.3.0/downloads.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.4.0m1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z</URL>
+      <MD5>db7c7ff09acd5d7820cc4d1eb0939cf9</MD5>
+      <SHA256>e73a54088e88e6465f578625d185933e85c3209ab7105deb755a8b8918b78cab</SHA256>
+      <FileName>Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z</FileName>
+      <FileSize>680772328</FileSize>
+    </Package>
+    <Package>
+      <URL>http://ultravideo.cs.tut.fi/video/Bosphorus_3840x2160_120fps_420_8bit_YUV_Y4M.7z</URL>
+      <MD5>815ca5830c8ea2f95545429817b96b1f</MD5>
+      <SHA256>d0fcb7d8cfc6e51c47ce8b427dab41ce38300c4b1a51a1903ddd5d86067c4c79</SHA256>
+      <FileName>Bosphorus_3840x2160_120fps_420_8bit_YUV_Y4M.7z</FileName>
+      <FileSize>2804470345</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/git/svt-av1-2.3.0/install.sh
+++ b/git/svt-av1-2.3.0/install.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+7z x Bosphorus_1920x1080_120fps_420_8bit_YUV_RAW.7z -aoa
+7z x Bosphorus_3840x2160_120fps_420_8bit_YUV_Y4M.7z -aoa
+
+rm -rf SVT-AV1-master
+git clone https://gitlab.com/AOMediaCodec/SVT-AV1.git SVT-AV1-master
+./SVT-AV1-master/Build/linux/build.sh release
+echo $? > ~/install-exit-status
+
+cd ~
+echo "#!/bin/sh
+./SVT-AV1-master/Bin/Release/SvtAv1EncApp \$@ > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status" > svt-av1
+chmod +x svt-av1

--- a/git/svt-av1-2.3.0/results-definition.xml
+++ b/git/svt-av1-2.3.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.4.0m1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Average Speed:		#_RESULT_# fps</OutputTemplate>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/git/svt-av1-2.3.0/test-definition.xml
+++ b/git/svt-av1-2.3.0/test-definition.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.4.0m1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>SVT-AV1</Title>
+    <AppVersion>Git</AppVersion>
+    <Description>This is a benchmark of the SVT-AV1 open-source video encoder/decoder. SVT-AV1 was originally developed by Intel as part of their Open Visual Cloud / Scalable Video Technology (SVT). Development of SVT-AV1 has since moved to the Alliance for Open Media as part of upstream AV1 development. SVT-AV1 is a CPU-based multi-threaded video encoder for the AV1 video format with a sample YUV video file.</Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>2.3.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, p7zip, yasm, cmake, git</ExternalDependencies>
+    <EnvironmentSize>2900</EnvironmentSize>
+    <ProjectURL>https://gitlab.com/AOMediaCodec/SVT-AV1</ProjectURL>
+    <RepositoryURL>https://gitlab.com/AOMediaCodec/SVT-AV1</RepositoryURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Encoder Mode</DisplayName>
+      <Identifier>enc-mode</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Preset 8</Name>
+          <Value>--preset 8</Value>
+          <Message>Fastest - Default</Message>
+        </Entry>
+        <Entry>
+          <Name>Preset 4</Name>
+          <Value>--preset 4 -n 160</Value>
+          <Message>Mid-Speed</Message>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Input</DisplayName>
+      <Identifier>input</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Bosphorus 1080p</Name>
+          <Value>-i Bosphorus_1920x1080_120fps_420_8bit_YUV.yuv -w 1920 -h 1080</Value>
+        </Entry>
+        <Entry>
+          <Name>Bosphorus 4K</Name>
+          <Value>-i Bosphorus_3840x2160.y4m -w 3840 -h 2160</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
Add another git/svt-av1 test based on the pts/svt-av1-2.3.0 test using the gitlab url as github is not updated at all.