### PR TITLE
fix build error on newer gcc systems

### DIFF
--- a/pts/gnupg-2.4.1/downloads.xml
+++ b/pts/gnupg-2.4.1/downloads.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.8.0m3-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.22.tar.bz2, http://src.fedoraproject.org//repo/pkgs/gnupg/gnupg-1.4.22.tar.bz2/sha512/c03acac0fa55761470bb085d78a44e2b99ebb187e8396cbb031a184b1e40bef2a40c91da07755d1a20610a3daa6aa1eefea2d12a0dbd5a79a45466166419c708/gnupg-1.4.22.tar.bz2, http://mirror1.ku.ac.th/ftp.gnupg.org/gcrypt/gnupg/gnupg-1.4.22.tar.bz2</URL>
+      <MD5>082bda3951a94743e76b83fcf3627547</MD5>
+      <SHA256>9594a24bec63a21568424242e3f198b9d9828dea5ff0c335e47b06f835f930b4</SHA256>
+      <FileSize>3746546</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/gnupg-2.4.1/install.sh
+++ b/pts/gnupg-2.4.1/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+mkdir $HOME/gnupg_
+
+tar -jxvf gnupg-1.4.22.tar.bz2
+cd gnupg-1.4.22/
+sed -i 's/CFLAGS="-g -O2"/CFLAGS="-g -O2 -fcommon"/' configure
+./configure --prefix=$HOME/gnupg_
+make -j $NUM_CPU_JOBS
+echo $? > ~/install-exit-status
+make install
+cd ..
+rm -rf gnupg-1.4.22/
+rm -rf gnupg_/share/
+
+echo pts-1234567890 > passphrase
+
+echo "#!/bin/sh
+./gnupg_/bin/gpg -c --no-options --passphrase-file passphrase -o /dev/null encryptfile 2>&1" > gnupg
+chmod +x gnupg

--- a/pts/gnupg-2.4.1/post.sh
+++ b/pts/gnupg-2.4.1/post.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f encryptfile

--- a/pts/gnupg-2.4.1/pre.sh
+++ b/pts/gnupg-2.4.1/pre.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+dd if=/dev/zero of=encryptfile bs=1M count=2048
+

--- a/pts/gnupg-2.4.1/results-definition.xml
+++ b/pts/gnupg-2.4.1/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.8.0m3-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/gnupg-2.4.1/test-definition.xml
+++ b/pts/gnupg-2.4.1/test-definition.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v7.8.0m3-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>GnuPG</Title>
+    <AppVersion>1.4.22</AppVersion>
+    <Description>This test times how long it takes to encrypt a file using GnuPG.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <SubTitle>2GB File Encryption</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>2.4.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities</ExternalDependencies>
+    <EnvironmentSize>8.4</EnvironmentSize>
+    <EnvironmentTestingSize>2048</EnvironmentTestingSize>
+    <ProjectURL>http://www.gnupg.org/</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+</PhoronixTestSuite>


### PR DESCRIPTION
Newer GCC defaults to -fno-common, which causes gnupg failed to compile.
Fix this issue by update compile options in configure.