### PR TITLE
Update yquake2 profile

### DIFF
--- a/pts/yquake2-1.1.2/downloads.xml
+++ b/pts/yquake2-1.1.2/downloads.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.6.0-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/yquake2/yquake2/archive/refs/tags/QUAKE2_8_01.zip</URL>
+      <MD5>90d34b2355e821324b05eff0500406bf</MD5>
+      <SHA256>d2f572f48ba1753fc773c5f4f4bd9a13f7944c0cf7a3374c3de60e815499dd59</SHA256>
+      <FileName>QUAKE2_8_01.zip</FileName>
+      <FileSize>2746632</FileSize>
+      <PlatformSpecific>Linux</PlatformSpecific>
+    </Package>
+    <Package>
+      <URL>https://github.com/yquake2/ref_vk/archive/refs/tags/v1.0.1.zip</URL>
+      <MD5>6dfbabb80bb6cc3dcdfae5fa85976da5</MD5>
+      <SHA256>eabd451bef3620f49d53a30f396e8abd7d228cf93f44f7f77f0eb71088e518ef</SHA256>
+      <FileName>v1.0.1.zip</FileName>
+      <FileSize>341809</FileSize>
+      <PlatformSpecific>Linux</PlatformSpecific>
+    </Package>
+    <Package>
+      <URL>https://master.dl.sourceforge.net/project/dcquake/quake2/demo/q2-314-demo-x86.exe, https://deponie.yamagi.org/quake2/idstuff/q2-314-demo-x86.exe</URL>
+      <MD5>4d1cd4618e80a38db59304132ea0856c</MD5>
+      <SHA256>7ace5a43983f10d6bdc9d9b6e17a1032ba6223118d389bd170df89b945a04a1e</SHA256>
+      <FileName>q2-314-demo-x86.exe</FileName>
+      <FileSize>39015499</FileSize>
+    </Package>
+    <Package>
+      <URL>https://deponie.yamagi.org/quake2/windows/quake2-8.01.zip</URL>
+      <MD5>c714d0ed832ace20e37966836e781238</MD5>
+      <SHA256>0b036e7a7ab00a6cc3b2f94045dd5e15d8ae37d3d626a4dcf1c9ecbd2f23596a</SHA256>
+      <FileName>quake2-8.01.zip</FileName>
+      <FileSize>4643879</FileSize>
+      <PlatformSpecific>Windows</PlatformSpecific>
+    </Package>
+    <Package>
+      <URL>https://github.com/yquake2/ref_vk/releases/download/v1.0.1/ref_vk-1.0.1.zip</URL>
+      <MD5>cb4a1ba3b10053b1dba2acf07fb6d27a</MD5>
+      <SHA256>1eb1619ff0741cd6648925f58b3d9adc4193ce1aa9630ac1e6e11a8c811d9c25</SHA256>
+      <FileName>ref_vk-1.0.1.zip</FileName>
+      <FileSize>285643</FileSize>
+      <PlatformSpecific>Windows</PlatformSpecific>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/yquake2-1.1.2/install.sh
+++ b/pts/yquake2-1.1.2/install.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+echo "clean up "
+rm -rf Install license.txt pts-install.xml readme.txt Setup.exe Splash yquake2-QUAKE2_8_01
+
+echo "unpack yquake"
+unzip -o QUAKE2_8_01.zip
+
+echo "compile yquake"
+cd yquake2-QUAKE2_8_01
+make
+echo $? > ~/install-exit-status
+cd ..
+
+echo "unpack yquake vulkan"
+unzip v1.0.1.zip
+
+echo "compile yquake"
+cd ref_vk-1.0.1
+make
+cp -v release/ref_vk.so ../yquake2-QUAKE2_8_01/release/
+echo $? > ~/install-exit-status
+cd ..
+
+echo "unpack quake 2 demo"
+unzip -o q2-314-demo-x86.exe
+cp -rv Install/Data/baseq2/pak0.pak yquake2-QUAKE2_8_01/release/baseq2/
+cp -rv Install/Data/baseq2/players yquake2-QUAKE2_8_01/release/baseq2/
+
+echo "add test profile"
+cat > yquake2-QUAKE2_8_01/release/baseq2/pts.cfg << EOF
+unbindall
+timedemo 1
+set nextdemo quit
+set demoloop "demomap q2demo1.dm2"
+vstr demoloop
+EOF
+
+echo "create run script"
+echo "#!/bin/sh
+cd yquake2-QUAKE2_8_01/release
+case \$OS_TYPE in
+	*)
+		./quake2 \$@ > \$LOG_FILE 2>&1
+		echo \$? > ~/test-exit-status
+	;;
+esac" > yquake2
+chmod +x yquake2
+

--- a/pts/yquake2-1.1.2/install_windows.sh
+++ b/pts/yquake2-1.1.2/install_windows.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+echo "clean up "
+rm -rf Install license.txt pts-install.xml readme.txt Setup.exe Splash quake2-8.01
+
+echo "unpack windows yquake"
+unzip quake2-8.01.zip
+
+echo "unpack windows yquake vulkan"
+unzip ref_vk-1.0.1.zip
+cp -v ref_vk-1.0.1/ref_vk.dll quake2-8.01/
+
+echo "unpack quake 2 demo"
+unzip q2-314-demo-x86.exe
+cp -rv Install/Data/baseq2/pak0.pak quake2-8.01/baseq2/
+cp -rv Install/Data/baseq2/players quake2-8.01/baseq2/
+
+echo "add test profile"
+cat > quake2-8.01/baseq2/pts.cfg << EOF
+unbindall
+timedemo 1
+set nextdemo quit
+set demoloop "demomap q2demo1.dm2"
+vstr demoloop
+EOF
+
+echo "create run script"
+echo "#!/bin/sh
+cd quake2-8.01
+./yquake2.exe \$@
+mv \${USERPROFILE}\\\\Documents\\\\YamagiQ2\\\\stdout.txt \$LOG_FILE" > yquake2
+chmod +x yquake2

--- a/pts/yquake2-1.1.2/results-definition.xml
+++ b/pts/yquake2-1.1.2/results-definition.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.6.0-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>632 frames, 1.1 seconds: #_RESULT_# fps</OutputTemplate>
+    <LineHint>fps</LineHint>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/yquake2-1.1.2/test-definition.xml
+++ b/pts/yquake2-1.1.2/test-definition.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.6.0-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>yquake2</Title>
+    <AppVersion>8.01</AppVersion>
+    <Description>This is a test of Yamagi Quake II. Yamagi Quake II is an enhanced client for id Software's Quake II with focus on offline and coop gameplay. </Description>
+    <ResultScale>Frames Per Second</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.2</Version>
+    <SupportedPlatforms>Linux, Windows</SupportedPlatforms>
+    <SoftwareType>Game</SoftwareType>
+    <TestType>Graphics</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>sdl2-development, build-utilities, curl, openal-development, vulkan-development</ExternalDependencies>
+    <RequiresDisplay>TRUE</RequiresDisplay>
+    <EnvironmentSize>64</EnvironmentSize>
+    <ProjectURL>https://www.yamagi.org/quake2/</ProjectURL>
+    <RepositoryURL>https://github.com/yquake2/yquake2</RepositoryURL>
+    <Maintainer>Denis Pauk</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments>+exec pts.cfg +set vid_fullscreen 0 +set r_retexturing 2 +set r_scale8bittextures 1 +set vid_maxfps 999</Arguments>
+    </Default>
+    <Option>
+      <DisplayName>Renderer</DisplayName>
+      <Identifier>renderer</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Software CPU</Name>
+          <Value>+set vid_renderer soft</Value>
+        </Entry>
+        <Entry>
+          <Name>OpenGL 1.x</Name>
+          <Value>+set vid_renderer gl1</Value>
+        </Entry>
+        <Entry>
+          <Name>OpenGL 3.x</Name>
+          <Value>+set vid_renderer gl3</Value>
+        </Entry>
+        <Entry>
+          <Name>Vulkan</Name>
+          <Value>+set vid_renderer vk</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Anisotropic texture filtering</DisplayName>
+      <Identifier>texture_filtering</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Off</Name>
+          <Value>+set r_anisotropic 0</Value>
+        </Entry>
+        <Entry>
+          <Name>On</Name>
+          <Value>+set r_anisotropic 16</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>MSAA</DisplayName>
+      <Identifier>msaa</Identifier>
+      <Menu>
+        <Entry>
+          <Name>Off</Name>
+          <Value>+set r_msaa_samples 0</Value>
+        </Entry>
+        <Entry>
+          <Name>On</Name>
+          <Value>+set r_msaa_samples 16</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Resolution</DisplayName>
+      <Identifier>resolution</Identifier>
+      <Menu>
+        <Entry>
+          <Name>1024x768</Name>
+          <Value>+set r_mode 10</Value>
+        </Entry>
+        <Entry>
+          <Name>1920 x 1080</Name>
+          <Value>+set r_mode 21</Value>
+        </Entry>
+        <Entry>
+          <Name>2560 x 1440</Name>
+          <Value>+set r_mode 25</Value>
+        </Entry>
+        <Entry>
+          <Name>3840 x 2160</Name>
+          <Value>+set r_mode 29</Value>
+        </Entry>
+        <Entry>
+          <Name>5120 x 2880</Name>
+          <Value>+set r_mode 31</Value>
+        </Entry>
+        <Entry>
+          <Name>7680 × 4320</Name>
+          <Value>+set r_mode -1 +set r_customwidth 7680 +set r_customheight 4320</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
Update yquake2 profile to use 8.01 version. 

Main difference is change max fps to 5 * vid_maxfps in benchmark mode ~ 5k fps limit and code has check for maximum msaa and r_anisotropic mode, and if value is bigger that supported by video driver,  smaller value is used automatically.  