### PR TITLE
Update downloads.xml to fix error when installing CPU suite

### DIFF
--- a/pts/rodinia-1.2.2/downloads.xml
+++ b/pts/rodinia-1.2.2/downloads.xml
@@ -3,7 +3,7 @@
 <PhoronixTestSuite>
   <Downloads>
     <Package>
-      <URL>http://www.cs.virginia.edu/~kw5na/lava/Rodinia/Packages/Current/rodinia_2.4.tar.bz2</URL>
+      <URL>http://www.cs.virginia.edu/~skadron/lava/Rodinia/Packages/rodinia_2.4.tar.bz2</URL>
       <MD5>4aba3e99b9b217909f6a7ec3bfd4a303</MD5>
       <SHA256>e48a51210e19fa97f920f218b6083856ba4c5751b4bf17bf68578ed8f32f90cc</SHA256>
       <FileSize>300454641</FileSize>


### PR DESCRIPTION
Update URL for previous Rodinia package to fix error when installing CPU suite. MD5, SHA256, and file size does not change.