### PR TITLE
pts/build-linux-kernel-1.14.0: Update against kernel 5.18.0

### DIFF
--- a/pts/build-linux-kernel-1.14.0/downloads.xml
+++ b/pts/build-linux-kernel-1.14.0/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.0-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://fr2.rpmfind.net/linux/kernel/v5.x/linux-5.18.tar.xz, https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.18.tar.xz, http://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel/v5.x/linux-5.18.tar.xz, https://mirror.clarkson.edu/linux/linux/kernel/v5.x/linux-5.18.tar.xz, https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.18.tar.xz</URL>
+      <MD5>58e80452e2d8e1993cd7ec95e697ab5a</MD5>
+      <SHA256>51f3f1684a896e797182a0907299cc1f0ff5e5b51dd9a55478ae63a409855cee</SHA256>
+      <FileName>linux-5.18.tar.xz</FileName>
+      <FileSize>129790264</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/build-linux-kernel-1.14.0/install.sh
+++ b/pts/build-linux-kernel-1.14.0/install.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "#!/bin/sh
+
+cd linux-5.18
+make -s -j \$NUM_CPU_CORES 2>&1
+echo \$? > ~/test-exit-status" > time-compile-kernel
+
+chmod +x time-compile-kernel

--- a/pts/build-linux-kernel-1.14.0/interim.sh
+++ b/pts/build-linux-kernel-1.14.0/interim.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd linux-5.18
+make clean

--- a/pts/build-linux-kernel-1.14.0/post.sh
+++ b/pts/build-linux-kernel-1.14.0/post.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+rm -rf linux-5.18

--- a/pts/build-linux-kernel-1.14.0/pre.sh
+++ b/pts/build-linux-kernel-1.14.0/pre.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+rm -rf linux-5.18
+tar -xf linux-5.18.tar.xz
+
+cd linux-5.18
+
+if [ -z "$@" ]
+then
+	# This is for old PTS clients not passing anything per older old test profile configs that may be in suite...
+	export LINUX_MAKE_CONFIG="defconfig"
+else
+	export LINUX_MAKE_CONFIG="$1"
+fi
+
+echo "make $LINUX_MAKE_CONFIG"
+make "$LINUX_MAKE_CONFIG"
+make clean
+
+scripts/config --set-val CONFIG_WERROR n

--- a/pts/build-linux-kernel-1.14.0/results-definition.xml
+++ b/pts/build-linux-kernel-1.14.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.0-->
+<PhoronixTestSuite>
+  <SystemMonitor>
+    <Sensor>sys.time</Sensor>
+  </SystemMonitor>
+</PhoronixTestSuite>

--- a/pts/build-linux-kernel-1.14.0/test-definition.xml
+++ b/pts/build-linux-kernel-1.14.0/test-definition.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.0-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Timed Linux Kernel Compilation</Title>
+    <AppVersion>5.18</AppVersion>
+    <Description>This test times how long it takes to build the Linux kernel in a default configuration (defconfig) for the architecture being tested or alternatively an allmodconfig for building all possible kernel modules for the build.</Description>
+    <ResultScale>Seconds</ResultScale>
+    <Proportion>LIB</Proportion>
+    <SubTitle>Time To Compile</SubTitle>
+    <Executable>time-compile-kernel</Executable>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.14.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, bc, bison, flex, openssl-development</ExternalDependencies>
+    <EnvironmentSize>982</EnvironmentSize>
+    <ProjectURL>http://www.kernel.org/</ProjectURL>
+    <RepositoryURL>https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git</RepositoryURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>libelf.h</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Build</DisplayName>
+      <Identifier>build</Identifier>
+      <Menu>
+        <Entry>
+          <Name>defconfig</Name>
+          <Value>defconfig</Value>
+          <Message>Default Kernel Build</Message>
+        </Entry>
+        <Entry>
+          <Name>allmodconfig</Name>
+          <Value>allmodconfig</Value>
+          <Message>This option is *much* more time consuming...</Message>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
We also disable CONFIG_WERROR to avoid compilation errors when using
newer compilers.