### PR TITLE
stress-ng-1.5.2: change the count number from 0 to -1 in stress-ng

### DIFF
--- a/pts/stress-ng-1.5.2/downloads.xml
+++ b/pts/stress-ng-1.5.2/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.3-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.14.00.tar.gz</URL>
+      <MD5>5f600736939abc976bf6ebfd1ae4da37</MD5>
+      <SHA256>d0cc53073e0c2499e15044fbd5a0df0176521575ea13fba01f67834b9e07d19d</SHA256>
+      <FileName>stress-ng-0.14.00.tar.gz</FileName>
+      <FileSize>1102022</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/stress-ng-1.5.2/install.sh
+++ b/pts/stress-ng-1.5.2/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+tar -xf stress-ng-0.14.00.tar.gz
+cd stress-ng-0.14.00
+if [ "$OS_TYPE" = "BSD" ]
+then
+	gmake
+else
+	make -j $NUM_CPU_PHYSICAL_CORES
+fi
+echo $? > ~/install-exit-status
+
+cd ~
+cat << EOF > stress-ng
+#!/bin/sh
+cd stress-ng-0.14.00
+./stress-ng \$@ > \$LOG_FILE 2>&1 
+echo \$? > ~/test-exit-status
+EOF
+chmod +x stress-ng

--- a/pts/stress-ng-1.5.2/results-definition.xml
+++ b/pts/stress-ng-1.5.2/results-definition.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.3-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>stress-ng: info: [2271] cpu             103656     30.03    596.91      0.00      #_RESULT_#       173.65</OutputTemplate>
+    <ResultScale>Bogo Ops/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/stress-ng-1.5.2/test-definition.xml
+++ b/pts/stress-ng-1.5.2/test-definition.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.3-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Stress-NG</Title>
+    <AppVersion>0.14</AppVersion>
+    <Description>Stress-NG is a Linux stress tool developed by Colin King of Canonical.</Description>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.5.2</Version>
+    <SupportedPlatforms>Linux, BSD, MacOSX</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, attr</ExternalDependencies>
+    <EnvironmentSize>18</EnvironmentSize>
+    <ProjectURL>https://github.com/ColinIanKing/stress-ng/</ProjectURL>
+    <RepositoryURL>https://github.com/ColinIanKing/stress-ng</RepositoryURL>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>sys/apparmor.h</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments>-t 30 --metrics-brief</Arguments>
+    </Default>
+    <Option>
+      <DisplayName>Test</DisplayName>
+      <Identifier>test</Identifier>
+      <Menu>
+        <Entry>
+          <Name>CPU Stress</Name>
+          <Value>--cpu -1 --cpu-method all</Value>
+        </Entry>
+        <Entry>
+          <Name>Crypto</Name>
+          <Value>--crypt -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Memory Copying</Name>
+          <Value>--memcpy -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Glibc Qsort Data Sorting</Name>
+          <Value>--qsort -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Glibc C String Functions</Name>
+          <Value>--str -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Vector Math</Name>
+          <Value>--vecmath -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Matrix Math</Name>
+          <Value>--matrix -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Forking</Name>
+          <Value>--fork -1</Value>
+        </Entry>
+        <Entry>
+          <Name>System V Message Passing</Name>
+          <Value>--msg -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Semaphores</Name>
+          <Value>--sem -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Socket Activity</Name>
+          <Value>--sock -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Context Switching</Name>
+          <Value>--switch -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Atomic</Name>
+          <Value>--atomic -1</Value>
+        </Entry>
+        <Entry>
+          <Name>CPU Cache</Name>
+          <Value>--cache -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Malloc</Name>
+          <Value>--malloc -1</Value>
+        </Entry>
+        <Entry>
+          <Name>MEMFD</Name>
+          <Value>--memfd -1</Value>
+        </Entry>
+        <Entry>
+          <Name>MMAP</Name>
+          <Value>--mmap -1</Value>
+        </Entry>
+        <Entry>
+          <Name>NUMA</Name>
+          <Value>--numa -1</Value>
+        </Entry>
+        <Entry>
+          <Name>x86_64 RdRand</Name>
+          <Value>--rdrand -1</Value>
+        </Entry>
+        <Entry>
+          <Name>SENDFILE</Name>
+          <Value>--sendfile -1</Value>
+        </Entry>
+        <Entry>
+          <Name>IO_uring</Name>
+          <Value>--io-uring -1</Value>
+        </Entry>
+        <Entry>
+          <Name>Futex</Name>
+          <Value>--futex -1</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
In the function stress_get_processors of stress-ng: 
count = 0 -> number of CPUs in system
count < 0 -> number of CPUs online

Using online CPU number will be more accurate if some of the CPU core are disabled or offline. For example, if we're doing the scaling performance test, we would like to set the actual online CPU number as the running instance number in stress-ng.