### PR TITLE
update the docker image name as it changed in dockerhub

### DIFF
--- a/pts/cloudsuite-ga-1.0.0/install.sh
+++ b/pts/cloudsuite-ga-1.0.0/install.sh
@@ -9,8 +9,8 @@ else
 	exit
 fi
 
-docker pull cloudsuite/graph-analytics
-docker pull cloudsuite/twitter-dataset-graph
+docker pull cloudsuite3/graph-analytics
+docker pull cloudsuite3/twitter-dataset-graph
 echo $? > ~/install-exit-status
 
 
@@ -18,10 +18,10 @@ echo "#!/bin/bash
 export HOME=\$DEBUG_REAL_HOME 
 
 # Start
-docker create --name data-ga cloudsuite/twitter-dataset-graph
+docker create --name data-ga cloudsuite3/twitter-dataset-graph
 
 # Run benchmark
-docker run --rm --volumes-from data-ga cloudsuite/graph-analytics --driver-memory 16g --executor-memory 16g \$@ > \$LOG_FILE 2>&1
+docker run --rm --volumes-from data-ga cloudsuite3/graph-analytics --driver-memory 16g --executor-memory 16g \$@ > \$LOG_FILE 2>&1
 echo \$? > ~/test-exit-status
 
 # Stop them


### PR DESCRIPTION
v3.0 images are moved to under cloudsuite3 instead of cloudsuite. For cloudsuite, it hosts images for v4.0 benchmark, while v4.0 is still working in progress