### PR TITLE
update hammerdb-mariadb to 1.1.0

### DIFF
--- a/pts/hammerdb-mariadb-1.1.0/downloads.xml
+++ b/pts/hammerdb-mariadb-1.1.0/downloads.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.4.0m1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://mirror.sobukus.de/files/src/mariadb/mariadb-10.8.2.tar.gz, https://archive.mariadb.org/mariadb-10.8.2/source/mariadb-10.8.2.tar.gz</URL>
+      <MD5>c021f7a62a86e2285c9cb7c0f0f6b233</MD5>
+      <SHA256>14e0f7f8817a41bbcb5ebdd2345a9bd44035fde7db45c028b6d4c35887ae956c</SHA256>
+      <FileName>mariadb-10.8.2.tar.gz</FileName>
+      <FileSize>86798824</FileSize>
+    </Package>
+    <Package>
+      <URL>https://github.com/TPC-Council/HammerDB/releases/download/v4.0/HammerDB-4.0-Linux.tar.gz</URL>
+      <MD5>fa9c4e2654a49f856cecf63c8ca9be5b</MD5>
+      <SHA256>9274d8158ba0830e5aafa9263fd865cf61163a0b2c190dfad4d4bf1b61bd6c90</SHA256>
+      <FileName>HammerDB-4.0-Linux.tar.gz</FileName>
+      <FileSize>5036787</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/hammerdb-mariadb-1.1.0/install.sh
+++ b/pts/hammerdb-mariadb-1.1.0/install.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+
+rm -rf mysql_
+# BUILD
+tar -xf mariadb-10.8.2.tar.gz
+mkdir ~/mysql_
+cd mariadb-10.8.2/BUILD/
+cmake -DCMAKE_INSTALL_PREFIX=$HOME/mysql_ -DCMAKE_BUILD_TYPE=Release ..
+if [ "$OS_TYPE" = "BSD" ]
+then
+        gmake -j $NUM_CPU_CORES
+else
+        make -j $NUM_CPU_CORES
+fi
+make install
+echo $? > ~/install-exit-status
+
+# SETUP
+# Moved to pre process to wipe .data each time
+#cd ~/mysql_
+#./scripts/mysql_install_db --no-defaults --user=`basename $DEBUG_REAL_HOME` --basedir=$HOME/mysql_ --ldata=$HOME/mysql_/.data
+#chmod -R 777 .data
+
+cd ~
+tar -xf HammerDB-4.0-Linux.tar.gz
+
+echo "[mysqld]
+skip-log-bin
+datadir=/data
+default_authentication_plugin=mysql_native_password
+socket=/tmp/mysql.sock
+port=3306
+bind_address=localhost
+# general
+max_connections=4000
+table_open_cache=8000
+table_open_cache_instances=16
+back_log=1500
+default_password_lifetime=0
+ssl=0
+performance_schema=OFF
+max_prepared_stmt_count=128000
+skip_log_bin=1
+character_set_server=latin1
+collation_server=latin1_swedish_ci
+transaction_isolation=REPEATABLE-READ
+# files
+innodb_file_per_table
+innodb_log_file_size=1024M
+innodb_log_files_in_group=32
+innodb_open_files=4000
+# buffers
+innodb_buffer_pool_size=64000M
+innodb_buffer_pool_instances=16
+innodb_log_buffer_size=64M
+# tune
+innodb_page_size=8192
+innodb_doublewrite=0
+innodb_thread_concurrency=0
+innodb_flush_log_at_trx_commit=0
+innodb_max_dirty_pages_pct=90
+innodb_max_dirty_pages_pct_lwm=10
+join_buffer_size=32K
+sort_buffer_size=32K
+innodb_use_native_aio=1
+innodb_stats_persistent=1
+innodb_spin_wait_delay=6
+innodb_max_purge_lag_delay=300000
+innodb_max_purge_lag=0
+innodb_flush_method=O_DIRECT_NO_FSYNC
+innodb_checksum_algorithm=none
+innodb_io_capacity=4000
+innodb_io_capacity_max=20000
+innodb_lru_scan_depth=9000
+innodb_change_buffering=none
+innodb_read_only=0
+innodb_page_cleaners=4
+innodb_undo_log_truncate=off
+# perf special
+innodb_adaptive_flushing=1
+innodb_flush_neighbors=0
+innodb_read_io_threads=16
+innodb_write_io_threads=16
+innodb_purge_threads=4
+innodb_adaptive_hash_index=0
+# monitoring
+innodb_monitor_enable='%'" > my.cnf
+ln -s my.cnf .my.cnf
+
+echo "#!/bin/sh
+cd HammerDB-4.0/
+export LD_LIBRARY_PATH=\$HOME/mysql_/lib/:\$LD_LIBRARY_PATH
+
+echo \"#vi mysqlrun.tcl
+puts \\\"SETTING CONFIGURATION\\\"
+dbset db mysql
+diset connection mysql_host localhost
+diset connection mysql_port 3306
+diset tpcc mysql_driver timed
+diset tpcc mysql_prepared false
+diset tpcc mysql_rampup 2
+diset tpcc mysql_duration 5
+diset tpcc mysql_user `basename $DEBUG_REAL_HOME`
+diset tpcc mysql_pass phoronix
+vuset logtotemp 1
+loadscript
+puts \\\"TEST STARTED\\\"
+vuset vu \$1
+vucreate
+vurun
+runtimer 500
+vudestroy
+puts \\\"TEST COMPLETE\\\"\" > mysqlrun.tcl
+
+./hammerdbcli auto mysqlrun.tcl > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status" > hammerdb-mariadb
+chmod +x hammerdb-mariadb

--- a/pts/hammerdb-mariadb-1.1.0/post.sh
+++ b/pts/hammerdb-mariadb-1.1.0/post.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# STOP SERVER
+cd mysql_
+./bin/mysqladmin -u `basename $DEBUG_REAL_HOME` -pphoronix shutdown
+sleep 5
+
+rm -rf .data/*

--- a/pts/hammerdb-mariadb-1.1.0/pre.sh
+++ b/pts/hammerdb-mariadb-1.1.0/pre.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+export LD_LIBRARY_PATH=\$HOME/mysql_/lib/:$LD_LIBRARY_PATH
+
+# SETUP
+cd $HOME/mysql_
+rm -rf .data/*
+./scripts/mysql_install_db --no-defaults --user=`basename $DEBUG_REAL_HOME` --basedir=$HOME/mysql_ --ldata=$HOME/mysql_/.data
+chmod -R 777 .data
+
+# START SERVER
+cd $HOME/mysql_
+if [ "$(whoami)" == "root" ] ; then
+    $HOME/mysql_/bin/mysqld_safe --no-defaults --max-connections=1000 --user=root --datadir=$HOME/mysql_/.data &
+else
+    $HOME/mysql_/bin/mysqld_safe --no-defaults --max-connections=1000 --datadir=$HOME/mysql_/.data &
+fi
+
+sleep 5
+
+$HOME/mysql_/bin/mysqladmin -u `basename $DEBUG_REAL_HOME` password 'phoronix'
+
+cd ~/HammerDB-4.0/
+
+echo "puts \"SETTING CONFIGURATION\"
+dbset db mysql
+diset connection mysql_host localhost
+diset connection mysql_port 3306
+diset tpcc mysql_count_ware $2
+diset tpcc mysql_partition true
+diset tpcc mysql_num_vu $1
+diset tpcc mysql_storage_engine innodb
+diset tpcc mysql_user `basename $DEBUG_REAL_HOME`
+diset tpcc mysql_pass phoronix
+print dict
+buildschema
+waittocomplete" > schemabuild.tcl
+
+./hammerdbcli auto schemabuild.tcl

--- a/pts/hammerdb-mariadb-1.1.0/results-definition.xml
+++ b/pts/hammerdb-mariadb-1.1.0/results-definition.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.4.0m1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Vuser 1:TEST RESULT : System achieved #_RESULT_# NOPM from 16917 MySQL TPM</OutputTemplate>
+    <LineHint>System achieved</LineHint>
+    <ResultScale>New Orders Per Minute</ResultScale>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>Vuser 1:TEST RESULT : System achieved 555 NOPM from #_RESULT_# MySQL TPM</OutputTemplate>
+    <LineHint>System achieved</LineHint>
+    <ResultScale>Transactions Per Minute</ResultScale>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/hammerdb-mariadb-1.1.0/test-definition.xml
+++ b/pts/hammerdb-mariadb-1.1.0/test-definition.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.4.0m1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>HammerDB - MariaDB</Title>
+    <AppVersion>10.5.9</AppVersion>
+    <Description>This is a MariaDB MySQL database server benchmark making use of the HammerDB benchmarking / load testing tool.</Description>
+    <ResultScale>New Orders Per Minute</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.0</Version>
+    <SupportedPlatforms>Linux, MacOSX, BSD</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <SupportedArchitectures>x86_64</SupportedArchitectures>
+    <ExternalDependencies>build-utilities, cmake, libevent, ncurses-development, bison, flex, openssl-development, zlib-development</ExternalDependencies>
+    <EnvironmentSize>10000</EnvironmentSize>
+    <ProjectURL>https://mariadb.com/</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Virtual Users</DisplayName>
+      <Identifier>virtual-users</Identifier>
+      <Menu>
+        <Entry>
+          <Name>8</Name>
+          <Value>8</Value>
+        </Entry>
+        <Entry>
+          <Name>16</Name>
+          <Value>16</Value>
+        </Entry>
+        <Entry>
+          <Name>32</Name>
+          <Value>32</Value>
+        </Entry>
+        <Entry>
+          <Name>64</Name>
+          <Value>64</Value>
+        </Entry>
+        <Entry>
+          <Name>128</Name>
+          <Value>128</Value>
+        </Entry>
+        <Entry>
+          <Name>256</Name>
+          <Value>256</Value>
+        </Entry>
+        <Entry>
+          <Name>512</Name>
+          <Value>512</Value>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Warehouses</DisplayName>
+      <Identifier>warehouses</Identifier>
+      <Menu>
+        <Entry>
+          <Name>250</Name>
+          <Value>250</Value>
+        </Entry>
+        <Entry>
+          <Name>500</Name>
+          <Value>500</Value>
+        </Entry>
+        <Entry>
+          <Name>1000</Name>
+          <Value>1000</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
the 1.0.0 mariadb is 10.5.9, which does not support openssl 3.0
bumps up it to 10.8.2 which supports openssl 3.0
