### PR TITLE
add LD_LIBRARY_PATH to let binary find so in pg_ built during install…

### DIFF
--- a/pts/hammerdb-postgresql-1.0.0/install.sh
+++ b/pts/hammerdb-postgresql-1.0.0/install.sh
@@ -91,6 +91,7 @@ cd ~
 tar -xf HammerDB-4.0-Linux.tar.gz
 
 echo "#!/bin/sh
+export LD_LIBRARY_PATH=$HOME/pg_/lib/:$LD_LIBRARY_PATH
 PGDATA=\$HOME/pg_/data/db/
 PGPORT=7777
 export PGDATA


### PR DESCRIPTION
otherwise, the executable binary cannot find pg_ lib, and fail to execute