### PR TITLE
add @latest tag at the end of go install

### DIFF
--- a/pts/go-benchmark-1.1.4/install.sh
+++ b/pts/go-benchmark-1.1.4/install.sh
@@ -7,7 +7,7 @@ tar -xf golang-benchmarks-121017.tar.gz -C $TESTDIR
 cd $TESTDIR
 mv go-benchmark-04122017/x x
 cd ~
-GOBIN=$PWD go install golang.org/x/benchmarks/...
+GOBIN=$PWD go install golang.org/x/benchmarks/...@latest
 
 cd ~
 echo "#!/bin/sh


### PR DESCRIPTION
go install usage is deprecated once it >1.16, need to add @latest at the end of the go install command, otherwise it will fail to generate executable binaries