### PR TITLE
Update to Stargate DAW 22.11.5

### DIFF
--- a/pts/stargate-1.0.2/downloads.xml
+++ b/pts/stargate-1.0.2/downloads.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.6.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/stargatedaw/stargate/archive/refs/tags/release-22.11.5.tar.gz</URL>
+      <MD5>377948c44b91588465cfc542fd6d2521</MD5>
+      <SHA256>2b4f3df3601fee9c5bceb9a34c69966a260c80460c7d8cc14095ad57a7fbc6dc</SHA256>
+      <FileName>release-22.11.5.tar.gz</FileName>
+      <FileSize>26679985</FileSize>
+    </Package>
+    <Package>
+      <URL>http://www.phoronix-test-suite.com/benchmark-files/stargate-benchmark-project-1.zip</URL>
+      <MD5>80810c29b24439bfbfc6e2aa46d27a8e</MD5>
+      <SHA256>ff3719ec0f0a995240ad216df5ad2511091191839980c7bb64baea0a376cfd0f</SHA256>
+      <FileName>stargate-benchmark-project-1.zip</FileName>
+      <FileSize>136140</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/stargate-1.0.2/install.sh
+++ b/pts/stargate-1.0.2/install.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+tar -xf release-22.11.5.tar.gz
+unzip -o stargate-benchmark-project-1.zip
+
+cd stargate-release-22.11.5/src
+
+pip3 install --user -r requirements.txt
+
+PLAT_FLAGS='-O3 -march=native' make -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+
+cd ~
+echo "#!/bin/bash
+cd stargate-release-21.10.9/src
+
+# Test can only handle up to 16 threads for now...
+THREADCOUNT=\$((\$NUM_CPU_PHYSICAL_CORES>16?16:\$NUM_CPU_PHYSICAL_CORES))
+
+# Based on https://github.com/stargatedaw/stargate/blob/main/docs/benchmarking.md
+
+# Sample rate.  Normally this is 44100 or 48000, but users sometimes choose
+# 96000 or 192000 for higher quality, at a much higher CPU cost.  Stargate DAW
+# has been tested at rates over 1,000,000, although such rates adversely affect
+# the audio by drastically changing the mix characteristics
+SR=\$1
+# Buffer size.  In real time audio, this affects latency, lower sizes have
+# less latency, but make less efficient use of the CPU. At 44100 sample rate,
+# 64 is a very low value, 512 is more normal, typical users may use 128
+# to 1024.  Doubling the sample rate effectively halves the latency of this
+# value, keep that in mind when changing one or the other.  Latenchy is
+# calculated as (BUF_SIZE / SR) * 1000 == latency in milliseconds
+BUF_SIZE=\$2
+# The number of worker threads to spawn.  The limit is 16, setting to zero
+# causes Stargate DAW to automatically select a very conservative value
+# of 1-4 depending on the CPU that was detected
+THREADS=\$THREADCOUNT
+# The project folder to render.  Specifically, this is the folder that contains
+# the `stargate.project` file.
+PROJECT=~/stargate/projects/myproject
+# The file to output.  If you want to keep all of the artifacts from this run,
+# change the filename between runs
+OUTFILE=test.wav
+# This is the musical beat number within the project to begin rendering at.
+# 0 being the first beat of the song.  It is best to get this by opening
+# the project in Stargate DAW as described above, but you could also use
+# arbitrary numbers.  This should be a low number, like 0 or 8
+START=8
+# This is the musical beat number within the project to stop rendering at
+# This should always be a (much) larger number than START
+END=340
+
+./engine/stargate-engine daw \$HOME/benchmark-project \${OUTFILE?} \${START?} \${END?} \${SR?} \${BUF_SIZE?} \${THREADS?} 0 0 0 > \$LOG_FILE
+echo \$? > ~/test-exit-status" > stargate
+chmod +x stargate

--- a/pts/stargate-1.0.2/results-definition.xml
+++ b/pts/stargate-1.0.2/results-definition.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.6.1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Ratio of render rate to real time (higher is better):  #_RESULT_# 1
+</OutputTemplate>
+    <StripFromResult>:</StripFromResult>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/stargate-1.0.2/test-definition.xml
+++ b/pts/stargate-1.0.2/test-definition.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.6.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Stargate Digital Audio Workstation</Title>
+    <AppVersion>21.10.9</AppVersion>
+    <Description>Stargate is an open-source, cross-platform digital audio workstation (DAW) software package with "a unique and carefully curated experience" with scalability from old systems up through modern multi-core systems. Stargate is GPLv3 licensed and makes use of Qt6 (PyQt6) for its user-interface.</Description>
+    <ResultScale>Render Ratio</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.1</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, python, fftw3-development, libtool, portaudio-development, python-numpy, qt5-development, vorbis-development</ExternalDependencies>
+    <EnvironmentSize>32</EnvironmentSize>
+    <ProjectURL>https://github.com/stargatedaw/stargate</ProjectURL>
+    <RepositoryURL>https://github.com/stargatedaw/stargate</RepositoryURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>cython3, ffmpeg, genisoimage, xgettext, jq, lame, alsa/asoundef.h, portmidi.h, sbsms.h, sndfile.h, f2py3, rubberband, mksquashfs, oggenc</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Sample Rate</DisplayName>
+      <Identifier>sample-rate</Identifier>
+      <Menu>
+        <Entry>
+          <Name>44100</Name>
+          <Value>44100</Value>
+          <Message>Default</Message>
+        </Entry>
+        <Entry>
+          <Name>480000</Name>
+          <Value>48000</Value>
+        </Entry>
+        <Entry>
+          <Name>96000</Name>
+          <Value>96000</Value>
+          <Message>More CPU Intensive</Message>
+        </Entry>
+        <Entry>
+          <Name>192000</Name>
+          <Value>192000</Value>
+          <Message>Highest Quality, Most CPU Intensive</Message>
+        </Entry>
+      </Menu>
+    </Option>
+    <Option>
+      <DisplayName>Buffer Size</DisplayName>
+      <Identifier>buffer-size</Identifier>
+      <Menu>
+        <Entry>
+          <Name>512</Name>
+          <Value>512</Value>
+        </Entry>
+        <Entry>
+          <Name>1024</Name>
+          <Value>1024</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
This release should fix the various CPU deadlocking issues that cause the benchmark to hang with high CPU usage.  Much tighter locking was added around all resources that are shared between threads.

Note that this has not been tested, I was not able to figure out how to run PTS against my local test profile.