### PR TITLE
Fix for csgo (1.7.2) runtime error on Windows clients

### DIFF
--- a/pts/csgo-1.7.2/install_windows.sh
+++ b/pts/csgo-1.7.2/install_windows.sh
@@ -26,19 +26,3 @@ cat csgo/SourceBench* >> \$LOG_FILE
 cat csgo/UNKNOWN >> \$LOG_FILE" > csgo
 chmod +x csgo
 echo 0 > ~/install-exit-status
-#!/bin/sh
-
-steam steam://install/730
-
-unzip -o csgo-demo-10.zip
-mv pts10.dem "C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Global Offensive\csgo"
-
-echo "#!/bin/sh
-cd \"C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Global Offensive\"
-rm -rf csgo/SourceBench*
-rm -f UNKNOWN
-./csgo.exe -game csgo \$@ +con_logfile log.log
-cat csgo/log.log* > \$LOG_FILE
-cat csgo/SourceBench* >> \$LOG_FILE
-cat csgo/UNKNOWN >> \$LOG_FILE" > csgo
-chmod +x csgo


### PR DESCRIPTION
Dear @michaellarabel and OpenBenchmarking test profile maintainers:

# Summary
I ran into a runtime error when trying to run the CS:GO test profile under Windows. I've developed a solution that will invoke CS:GO via the Steam CLI for running the `csgo` test profile on Windows systems. Please review and merge.

I appreciate any time & effort given to this pull request. Should you have any questions, please add comments to this pull request.

Sincerely,
Tad

# Problem & Proposed Solution
## The problem that prevents test runs under Windows
When PTS runs CS:GO, a runtime error occurs (see attached screenshot).
![CSGO 2023-01-05 151051](https://user-images.githubusercontent.com/121957038/210886897-bdab69da-0a64-42d5-b651-0a3435bd4c65.jpg)
The problem appears to be caused by the `csgo` test profile invoking `csgo.exe` directly on Windows clients.

## Proposed solution
Instead of the Windows test profile invoking `csgo.exe`, CS:GO is invoked via the [Steam CLI](https://developer.valvesoftware.com/wiki/Command_Line_Options#Steam).

### Solution implementation details
This pull request contains the following changes to the `csgo` test profile for Windows clients:

1. Commit `a4f099e`: Find Steam configuration data in the Windows Registry.
2. Commit `9df5db1`: Update existing test logic to use Steam configuration data and the Steam CLI.
3. Commit `7d57b25`: Invoke CS:GO via the Steam CLI, and add logic for the test profile to wait for `csgo.exe` to quit.

#### New dependencies introduced by the proposed solution
Windows PowerShell becomes a new dependency to run the `csgo` test profile on Windows clients. Specifically, the cmdlet [`Wait-Process`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/wait-process) is used to control test profile execution on Windows clients, since invoking CS:GO via Steam CLI will return immediately.

Impact on OpenBenchmarking users' ability to quickly and easily run `csgo` on Windows systems due to the use of PowerShell cmdlets is anticipated to be minuscule. Microsoft has integrated PowerShell into Windows starting with the release of Windows 7 Service Pack 1 (kernel 6.1.7601)[^1] and Microsoft introduced `Wait-Process` as a [cmdlet in PowerShell v2.0](https://social.technet.microsoft.com/wiki/contents/articles/13876.powershell-2-0-cmdlets.aspx). All of the Windows test results containing `csgo` runs---that are hosted on OpenBenchmarking.org---as of the date of this pull request used Windows 10 or later[^2].

This additional dependency is **not** expected to require PTS to manually check for and install PowerShell on Windows systems because it is **not** anticipated that there is interest in using PTS to run the `csgo` test profile on systems running Windows 7 (kernel 6.1.7600) or earlier.

[^1]: Microsoft states, "[Windows PowerShell comes installed by default in every Windows, starting with Windows 7 SP1 and Windows Server 2008 R2 SP1,](https://learn.microsoft.com/en-us/powershell/scripting/windows-powershell/install/installing-windows-powershell)" and PowerShell's [Release History](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle#release-history) indicates that version 2.0 was, "Integrated in Windows 7 and Windows Server 2008 R2".
[^2]: No results are returned using OpenBenchmarking.org's integrated search for the queries: 'csgo "Windows 7"' and 'csgo "Windows 8"'---in the absence of _any_ search results it's presumed that the `csgo` test profile has _never_ been run on a version of Windows prior to Windows 10.