### PR TITLE
memcached-1.1.0: Add 1:100 Set:Get ratio tests and fix memcached server not killed

### DIFF
--- a/pts/memcached-1.1.0/downloads.xml
+++ b/pts/memcached-1.1.0/downloads.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://www.memcached.org/files/memcached-1.6.18.tar.gz</URL>
+      <MD5>afddef72d2109619b89e482c2d6a4a4f</MD5>
+      <SHA256>cbdd6ab8810649ac5d92fcd0fcb0ca931d8a9dbd0ad8cc575b47222eedd64158</SHA256>
+      <FileName>memcached-1.6.18.tar.gz</FileName>
+      <FileSize>1081928</FileSize>
+    </Package>
+    <Package>
+      <URL>https://github.com/RedisLabs/memtier_benchmark/archive/refs/tags/1.4.0.tar.gz</URL>
+      <MD5>536666de87f3db01bd83181d3cd2cea8</MD5>
+      <SHA256>e154e1cc2e8bc99634c3a947a4dfad885de9d28a78e3cc18bcec6254f1aa4992</SHA256>
+      <FileName>memtier_benchmark-1.4.0.tar.gz</FileName>
+      <FileSize>315519</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/memcached-1.1.0/install.sh
+++ b/pts/memcached-1.1.0/install.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+tar -xzvf memcached-1.6.18.tar.gz
+cd memcached-1.6.18
+
+# Allow run as root
+patch -p0 <<'EOF'
+--- memcached.c.orig	2022-08-19 13:51:28.705427565 -0400
++++ memcached.c	2022-08-19 13:52:03.426871004 -0400
+@@ -5810,7 +5810,7 @@
+     }
+ 
+     /* lose root privileges if we have them */
+-    if (getuid() == 0 || geteuid() == 0) {
++    if (false) {
+         if (username == 0 || *username == '\0') {
+             fprintf(stderr, "can't run as root without the -u switch\n");
+             exit(EX_USAGE);
+EOF
+
+./configure
+make
+retVal=$?
+if [ $retVal -ne 0 ]; then
+	echo $retVal > ~/install-exit-status
+	exit $retVal
+fi
+
+cd ~
+tar -xf memtier_benchmark-1.4.0.tar.gz
+cd memtier_benchmark-1.4.0/
+autoreconf -ivf
+./configure
+make -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+
+cd ~
+echo "#!/bin/sh
+cd memcached-1.6.18
+
+./memcached -c 4096 -t \$NUM_CPU_CORES &
+MEMCACHED_PID=\$!
+sleep 6
+
+cd ~/memtier_benchmark-1.4.0/
+./memtier_benchmark --hide-histogram -t \$NUM_CPU_CORES \$@ > \$LOG_FILE
+kill \$MEMCACHED_PID" > memcached
+chmod +x memcached

--- a/pts/memcached-1.1.0/results-definition.xml
+++ b/pts/memcached-1.1.0/results-definition.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>Totals     #_RESULT_#     13833.49     36766.29     63.52700      6330.95 </OutputTemplate>
+    <LineHint>Totals</LineHint>
+    <ResultScale>Ops/sec</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/memcached-1.1.0/test-definition.xml
+++ b/pts/memcached-1.1.0/test-definition.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Memcached</Title>
+    <AppVersion>1.6.18</AppVersion>
+    <Description>Memcached is a high performance, distributed memory object caching system. This Memcached test profiles makes use of memtier_benchmark for excuting this CPU/memory-focused server benchmark.</Description>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.1.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Application</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, libevent, pcre, zlib-development, openssl-development, libtool</ExternalDependencies>
+    <EnvironmentSize>64</EnvironmentSize>
+    <ProjectURL>https://memcached.org/</ProjectURL>
+    <RepositoryURL>https://github.com/memcached/memcached</RepositoryURL>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>pkg-config</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments>-P memcache_text -c 1 -p 11211 --pipeline=16 --test-time=60</Arguments>
+    </Default>
+    <Option>
+      <DisplayName>Set To Get Ratio</DisplayName>
+      <Identifier>ratio</Identifier>
+      <ArgumentPrefix>--ratio=</ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>1:100</Name>
+          <Value>1:100</Value>
+        </Entry>
+        <Entry>
+          <Name>1:10</Name>
+          <Value>1:10</Value>
+        </Entry>
+        <Entry>
+          <Name>1:5</Name>
+          <Value>1:5</Value>
+        </Entry>
+        <Entry>
+          <Name>1:1</Name>
+          <Value>1:1</Value>
+        </Entry>
+        <Entry>
+          <Name>5:1</Name>
+          <Value>5:1</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
1. Add 1:100 ratio option to cover a majority of reading tests
2. Fix memcached server not killed
3. Upgrade memcached to latest 1.6.18