### PR TITLE
pts/stress-ng-1.7.0: Update against V0.15.04 upstream

### DIFF
--- a/pts/stress-ng-1.7.0/downloads.xml
+++ b/pts/stress-ng-1.7.0/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.15.04.tar.gz</URL>
+      <MD5>3701471191b41014aade78835ba887fe</MD5>
+      <SHA256>92922b979b5ca6ee05b03fd792c32a0b25a01fea6161b418b5e672c64ffb549f</SHA256>
+      <FileName>stress-ng-0.15.04.tar.gz</FileName>
+      <FileSize>3797315</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/stress-ng-1.7.0/install.sh
+++ b/pts/stress-ng-1.7.0/install.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+tar -xf stress-ng-0.15.04.tar.gz
+cd stress-ng-0.15.04
+if [ "$OS_TYPE" = "BSD" ]
+then
+	gmake
+else
+	make -j $NUM_CPU_PHYSICAL_CORES
+fi
+echo $? > ~/install-exit-status
+
+cd ~
+cat << EOF > stress-ng
+#!/bin/sh
+cd stress-ng-0.15.04
+./stress-ng \$@ > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status
+EOF
+chmod +x stress-ng

--- a/pts/stress-ng-1.7.0/results-definition.xml
+++ b/pts/stress-ng-1.7.0/results-definition.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>stress-ng: info: [2271] cpu             103656     30.03    596.91      0.00      #_RESULT_#       173.65</OutputTemplate>
+    <ResultScale>Bogo Ops/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/stress-ng-1.7.0/test-definition.xml
+++ b/pts/stress-ng-1.7.0/test-definition.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>Stress-NG</Title>
+    <AppVersion>0.15.04</AppVersion>
+    <Description>Stress-NG is a Linux stress tool developed by Colin Ian King.</Description>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.7.0</Version>
+    <SupportedPlatforms>Linux, BSD, MacOSX</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, attr</ExternalDependencies>
+    <EnvironmentSize>18</EnvironmentSize>
+    <ProjectURL>https://github.com/ColinIanKing/stress-ng/</ProjectURL>
+    <RepositoryURL>https://github.com/ColinIanKing/stress-ng</RepositoryURL>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>sys/apparmor.h</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments>-t 30 --metrics-brief</Arguments>
+    </Default>
+    <Option>
+      <DisplayName>Test</DisplayName>
+      <Identifier>test</Identifier>
+      <Menu>
+        <Entry>
+          <Name>CPU Stress</Name>
+          <Value>--cpu -1 --cpu-method all --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Crypto</Name>
+          <Value>--crypt -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Memory Copying</Name>
+          <Value>--memcpy -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Glibc Qsort Data Sorting</Name>
+          <Value>--qsort -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Glibc C String Functions</Name>
+          <Value>--str -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Vector Math</Name>
+          <Value>--vecmath -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Matrix Math</Name>
+          <Value>--matrix -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Forking</Name>
+          <Value>--fork -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>System V Message Passing</Name>
+          <Value>--msg -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Semaphores</Name>
+          <Value>--sem -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Socket Activity</Name>
+          <Value>--sock -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Context Switching</Name>
+          <Value>--switch -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Atomic</Name>
+          <Value>--atomic -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>CPU Cache</Name>
+          <Value>--cache -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Malloc</Name>
+          <Value>--malloc -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>MEMFD</Name>
+          <Value>--memfd -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>MMAP</Name>
+          <Value>--mmap -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>NUMA</Name>
+          <Value>--numa -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>x86_64 RdRand</Name>
+          <Value>--rdrand -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>SENDFILE</Name>
+          <Value>--sendfile -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>IO_uring</Name>
+          <Value>--io-uring -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Futex</Name>
+          <Value>--futex -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Mutex</Name>
+          <Value>--mutex -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Function Call</Name>
+          <Value>--funccall -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Poll</Name>
+          <Value>--poll -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Hash</Name>
+          <Value>--hash -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Pthread</Name>
+          <Value>--pthread -1 --no-rand-seed</Value>
+        </Entry>
+        <Entry>
+          <Name>Zlib</Name>
+          <Value>--zlib -1 --no-rand-seed</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
Move to V0.15.04, add in some more stable test cases, update stress-ng author's name now that they have left Canonical.