### PR TITLE
pts/stress-ng-1.7.0: update to bug fix release of stress-ng 0.15.06

### DIFF
--- a/pts/stress-ng-1.7.0/downloads.xml
+++ b/pts/stress-ng-1.7.0/downloads.xml
@@ -3,10 +3,10 @@
 <PhoronixTestSuite>
   <Downloads>
     <Package>
-      <URL>https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.15.04.tar.gz</URL>
+      <URL>https://github.com/ColinIanKing/stress-ng/archive/refs/tags/V0.15.06.tar.gz</URL>
       <MD5>3701471191b41014aade78835ba887fe</MD5>
       <SHA256>92922b979b5ca6ee05b03fd792c32a0b25a01fea6161b418b5e672c64ffb549f</SHA256>
-      <FileName>stress-ng-0.15.04.tar.gz</FileName>
+      <FileName>stress-ng-0.15.06.tar.gz</FileName>
       <FileSize>3797315</FileSize>
     </Package>
   </Downloads>

--- a/pts/stress-ng-1.7.0/install.sh
+++ b/pts/stress-ng-1.7.0/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-tar -xf stress-ng-0.15.04.tar.gz
-cd stress-ng-0.15.04
+tar -xf stress-ng-0.15.06.tar.gz
+cd stress-ng-0.15.06
 if [ "$OS_TYPE" = "BSD" ]
 then
 	gmake
@@ -11,7 +11,7 @@ echo $? > ~/install-exit-status
 cd ~
 cat << EOF > stress-ng
 #!/bin/sh
-cd stress-ng-0.15.04
+cd stress-ng-0.15.06
 ./stress-ng \$@ > \$LOG_FILE 2>&1
 echo \$? > ~/test-exit-status
 EOF

--- a/pts/stress-ng-1.7.0/test-definition.xml
+++ b/pts/stress-ng-1.7.0/test-definition.xml
@@ -3,7 +3,7 @@
 <PhoronixTestSuite>
   <TestInformation>
     <Title>Stress-NG</Title>
-    <AppVersion>0.15.04</AppVersion>
+    <AppVersion>0.15.06</AppVersion>
     <Description>Stress-NG is a Linux stress tool developed by Colin Ian King.</Description>
     <TimesToRun>3</TimesToRun>
   </TestInformation>
@@ -71,7 +71,7 @@
         </Entry>
         <Entry>
           <Name>Socket Activity</Name>
-          <Value>--sock -1 --no-rand-seed</Value>
+          <Value>--sock -1 --no-rand-seed --sock-zerocopy</Value>
         </Entry>
         <Entry>
           <Name>Context Switching</Name>


### PR DESCRIPTION
Versions 0.15.04 and 0.15.05 contained some regressions, so update to the bugfix release 0.15.06.

Update the sock stressor to use the rawsock mode (if it's available) as this is a minor improvement of the underlying network stack benchmark that removes the need for a userspace/kernel boundary memory copy per send/recv and is more in keeping with modern performant socket utilization patterns.