### PR TITLE
InfluxDB: Add support for AArch64 testing on Linux

### DIFF
--- a/pts/influxdb-1.0.1/downloads.xml
+++ b/pts/influxdb-1.0.1/downloads.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!--Phoronix Test Suite v10.8.2-->
+<!--Phoronix Test Suite v10.8.4-->
 <PhoronixTestSuite>
   <Downloads>
     <Package>
@@ -9,6 +9,16 @@
       <FileName>influxdb-1.8.2_linux_amd64.tar.gz</FileName>
       <FileSize>63461822</FileSize>
       <PlatformSpecific>Linux</PlatformSpecific>
+      <ArchitectureSpecific>x86_64</ArchitectureSpecific>
+    </Package>
+    <Package>
+      <URL>https://dl.influxdata.com/influxdb/releases/influxdb-1.8.2_linux_arm64.tar.gz</URL>
+      <MD5>1eccc3ec5679b0a684f4b7b94e78b4cb</MD5>
+      <SHA256>cbbaba181a86087c13dec7e2ee9e4510b2e84011c7401c0d20c1a964ab802eda</SHA256>
+      <FileName>influxdb-1.8.2_linux_arm64.tar.gz</FileName>
+      <FileSize>59150546</FileSize>
+      <PlatformSpecific>Linux</PlatformSpecific>
+      <ArchitectureSpecific>aarch64</ArchitectureSpecific>
     </Package>
   </Downloads>
 </PhoronixTestSuite>

--- a/pts/influxdb-1.0.1/install.sh
+++ b/pts/influxdb-1.0.1/install.sh
@@ -3,7 +3,12 @@
 rm -rf src
 rm -rf .cache
 export GOPATH=$HOME
-tar -xf influxdb-1.8.2_linux_amd64.tar.gz
+if [ $OS_ARCH = "aarch64" ]
+then
+	tar -xf influxdb-1.8.2_linux_arm64.tar.gz
+else
+	tar -xf influxdb-1.8.2_linux_amd64.tar.gz
+fi
 go get github.com/influxdata/inch/cmd/inch
 if [ $? -ne 0 ]
 then


### PR DESCRIPTION
Dear @michaellarabel:

Requesting that support for Linux-AArch64 be added to the `influxdb` test profile.

The changes proposed in this pull request are compatible with the existing `influxdb-1.0.1` test results—i.e., the AArch64 results are directly comparable to the existing x86_64 results.