### PR TITLE
`srsran-2.x`: Add new deps introduced in srsRAN release 23.3

### DIFF
--- a/pts/srsran-2.0.0/test-definition.xml
+++ b/pts/srsran-2.0.0/test-definition.xml
@@ -21,7 +21,7 @@
     <ProjectURL>https://srs.io/</ProjectURL>
     <RepositoryURL>https://github.com/srsran/srsRAN_Project</RepositoryURL>
     <Maintainer>Michael Larabel</Maintainer>
-    <SystemDependencies>libbladeRF.h, mbedtls/aes.h, libmbedtls.so, libboost_program_options.so, /usr/include/libconfig.h++, libconfig++.so, netinet/sctp.h, libsctp.so, yaml-cpp/yaml.h</SystemDependencies>
+    <SystemDependencies>libbladeRF.h, mbedtls/aes.h, libmbedtls.so, libboost_program_options.so, /usr/include/libconfig.h++, libconfig++.so, netinet/sctp.h, libsctp.so, yaml-cpp/yaml.h, libgtest.a, gtest/gtest.h</SystemDependencies>
   </TestProfile>
   <TestSettings>
     <Option>


### PR DESCRIPTION
Dear @michaellarabel:

It looks like the folks over at SRS added [GoogleTest as an additional dependency](https://github.com/srsran/srsRAN_Project/tree/release_23_3#build-preparation) for release 23.3 of srsRAN.

This pull request adds GoogleTest as a system dependency by adding the following system dependencies to the srsRAN-2.x test profile:
- `libgtest.a` is GoogleTest's static library. (runtime lib package)
- `gtest/gtest.h` is GoogleTest's header file. (dev package)

Please review and update the srsRAN test-profile as necessary.
Sincerely,
Tad