### PR TITLE
`hpcc`: Improve multi-arch installation

### DIFF
--- a/pts/hpcc-1.2.8/install.sh
+++ b/pts/hpcc-1.2.8/install.sh
@@ -123,18 +123,18 @@ then
 	LA_INCLUDE=/usr/include
 	LA_LIBS="-L$LA_PATH -lblas"
 	LA_VERSION="ATLAS"
-elif [ -d /usr/lib/x86_64-linux-gnu/atlas ]
+elif [ -d /usr/lib/${OS_ARCH}-linux-gnu/atlas ]
 then
 	# ATLAS on Ubuntu
-	LA_PATH=/usr/lib/x86_64-linux-gnu/atlas
-	LA_INCLUDE=/usr/include/x86_64-linux-gnu/
+	LA_PATH=/usr/lib/${OS_ARCH}-linux-gnu/atlas
+	LA_INCLUDE=/usr/include/${OS_ARCH}-linux-gnu/
 	LA_LIBS="-L$LA_PATH -lblas"
 	LA_VERSION="ATLAS"
-elif [ -d /usr/lib/x86_64-linux-gnu/blas ]
+elif [ -d /usr/lib/${OS_ARCH}-linux-gnu/blas ]
 then
 	# OpenBLAS on Ubuntu
-	LA_PATH=/usr/lib/x86_64-linux-gnu/blas
-	LA_INCLUDE=/usr/include/x86_64-linux-gnu/
+	LA_PATH=/usr/lib/${OS_ARCH}-linux-gnu/blas
+	LA_INCLUDE=/usr/include/${OS_ARCH}-linux-gnu/
 	LA_LIBS="-L$LA_PATH -lblas"
 	LA_VERSION="OpenBLAS"
 fi

--- a/pts/hpcc-1.2.8/install.sh
+++ b/pts/hpcc-1.2.8/install.sh
@@ -16,28 +16,20 @@ then
 	MPI_LIBS=/usr/lib/openmpi/lib/libmpi.so
 	MPI_CC=/usr/bin/mpicc.openmpi
 	MPI_VERSION=`$MPI_CC -showme:version 2>&1 | grep MPI | cut -d "(" -f1  | cut -d ":" -f2`
-elif [ -d /usr/lib/x86_64-linux-gnu/openmpi/ ] && [ -d /usr/include/openmpi/ ]
+elif [ -d /usr/lib/${OS_ARCH}-linux-gnu/openmpi/ ] && [ -d /usr/include/openmpi/ ]
 then
         # OpenMPI On Debian
-        MPI_PATH=/usr/lib/x86_64-linux-gnu/openmpi
+        MPI_PATH=/usr/lib/${OS_ARCH}-linux-gnu/openmpi
         MPI_INCLUDE=/usr/include/openmpi/
-        MPI_LIBS=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so
+        MPI_LIBS=/usr/lib/${OS_ARCH}-linux-gnu/openmpi/lib/libmpi.so
         MPI_CC=/usr/bin/mpicc
         MPI_VERSION=`$MPI_CC -showme:version 2>&1 | grep MPI | cut -d "(" -f1  | cut -d ":" -f2`
-elif [ -d /usr/lib/x86_64-linux-gnu/openmpi/ ] && [ -d /usr/lib/x86_64-linux-gnu/openmpi/include/ ]
+elif [ -d /usr/lib/${OS_ARCH}-linux-gnu/openmpi/ ] && [ -d /usr/lib/${OS_ARCH}-linux-gnu/openmpi/include/ ]
 then
         # OpenMPI On Newer Ubuntu
-        MPI_PATH=/usr/lib/x86_64-linux-gnu/openmpi
-        MPI_INCLUDE=/usr/lib/x86_64-linux-gnu/openmpi/include/
-        MPI_LIBS=/usr/lib/x86_64-linux-gnu/openmpi/lib/libmpi.so
-        MPI_CC=/usr/bin/mpicc
-        MPI_VERSION=`$MPI_CC -showme:version 2>&1 | grep MPI | cut -d "(" -f1  | cut -d ":" -f2`
-elif [ -d /usr/lib/aarch64-linux-gnu/openmpi/ ] && [ -d /usr/lib/aarch64-linux-gnu/openmpi/include/ ]
-then
-        # OpenMPI On Newer Ubuntu AArch64
-        MPI_PATH=/usr/lib/aarch64-linux-gnu/openmpi
-        MPI_INCLUDE=/usr/lib/aarch64-linux-gnu/openmpi/include/
-        MPI_LIBS=/usr/lib/aarch64-linux-gnu/openmpi/lib/libmpi.so
+        MPI_PATH=/usr/lib/${OS_ARCH}-linux-gnu/openmpi
+        MPI_INCLUDE=/usr/lib/${OS_ARCH}-linux-gnu/openmpi/include/
+        MPI_LIBS=/usr/lib/${OS_ARCH}-linux-gnu/openmpi/lib/libmpi.so
         MPI_CC=/usr/bin/mpicc
         MPI_VERSION=`$MPI_CC -showme:version 2>&1 | grep MPI | cut -d "(" -f1  | cut -d ":" -f2`
 elif [ -d /usr/lib64/openmpi ] && [ -x /usr/bin/mpicc ]
@@ -52,7 +44,7 @@ elif [ -d /usr/lib64/openmpi ] && [ -x /usr/lib64/openmpi/bin/mpicc ]
 then
 	# OpenMPI On RHEL
 	MPI_PATH=/usr/lib64/openmpi
-	MPI_INCLUDE=/usr/include/openmpi-x86_64/
+	MPI_INCLUDE=/usr/include/openmpi-${OS_ARCH}/
 	MPI_LIBS=/usr/lib64/openmpi/lib/libmpi.so
 	MPI_CC=/usr/lib64/openmpi/bin/mpicc
 	MPI_VERSION=`$MPI_CC -showme:version 2>&1 | grep MPI | cut -d "(" -f1  | cut -d ":" -f2`
@@ -80,11 +72,11 @@ then
 	MPI_LIBS=/usr/lib/mpich2/lib/libmpich.so
 	MPI_CC=/usr/bin/mpicc.mpich2
 	MPI_VERSION=`$MPI_CC -v 2>&1 | grep "MPICH2 version"`
-elif [ -d /usr/include/mpich2-x86_64 ]
+elif [ -d /usr/include/mpich2-${OS_ARCH} ]
 then
 	# MPICH2
-	MPI_PATH=/usr/include/mpich2-x86_64
-	MPI_INCLUDE=/usr/include/mpich2-x86_64
+	MPI_PATH=/usr/include/mpich2-${OS_ARCH}
+	MPI_INCLUDE=/usr/include/mpich2-${OS_ARCH}
 	MPI_LIBS=/usr/lib64/mpich2/lib/libmpich.so
 	MPI_CC=/usr/bin/mpicc
 	MPI_VERSION=`$MPI_CC -v 2>&1 | grep "MPICH2 version"`

--- a/pts/hpcc-1.2.8/install.sh
+++ b/pts/hpcc-1.2.8/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 readonly install_error_MPI_NOT_FOUND=1000  # Install Error: Unable to find an MPI toolchain to use. 
-readonly install_error_LA_NOT_FOUND=2000   # Install Error: Unable to find a linear algebra toolchain to use.
+readonly install_error_LA_NOT_FOUND=1001   # Install Error: Unable to find a linear algebra toolchain to use.
 readonly errno_ENOENT=2			   # No such file or directory. See also: errno(3).
 
 tar -zxvf hpcc-1.5.0.tar.gz

--- a/pts/hpcc-1.2.8/install.sh
+++ b/pts/hpcc-1.2.8/install.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+readonly install_error_MPI_NOT_FOUND=100  # Install Error: Unable to find an MPI toolchain to use. 
+readonly install_error_LA_NOT_FOUND=200   # Install Error: Unable to find a linear algebra toolchain to use.
+
 tar -zxvf hpcc-1.5.0.tar.gz
 cd hpcc-1.5.0
 
@@ -80,6 +83,9 @@ then
 	MPI_LIBS=/usr/lib64/mpich2/lib/libmpich.so
 	MPI_CC=/usr/bin/mpicc
 	MPI_VERSION=`$MPI_CC -v 2>&1 | grep "MPICH2 version"`
+else
+	echo $install_error_MPI_NOT_FOUND > ~/install-exit-status
+	exit $install_error_MPI_NOT_FOUND
 fi
 
 # Find Linear Algebra Package To Use
@@ -129,6 +135,9 @@ then
 	LA_INCLUDE=/usr/include/${OS_ARCH}-linux-gnu/
 	LA_LIBS="-L$LA_PATH -lblas"
 	LA_VERSION="OpenBLAS"
+else
+	echo $install_error_LA_NOT_FOUND > ~/install-exit-status
+	exit $install_error_LA_NOT_FOUND
 fi
 
 if [ ! "X$MPI_VERSION" = "X" ]

--- a/pts/hpcc-1.2.8/install.sh
+++ b/pts/hpcc-1.2.8/install.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-readonly install_error_MPI_NOT_FOUND=100  # Install Error: Unable to find an MPI toolchain to use. 
-readonly install_error_LA_NOT_FOUND=200   # Install Error: Unable to find a linear algebra toolchain to use.
+readonly install_error_MPI_NOT_FOUND=1000  # Install Error: Unable to find an MPI toolchain to use. 
+readonly install_error_LA_NOT_FOUND=2000   # Install Error: Unable to find a linear algebra toolchain to use.
+readonly errno_ENOENT=2			   # No such file or directory. See also: errno(3).
 
 tar -zxvf hpcc-1.5.0.tar.gz
 cd hpcc-1.5.0
@@ -85,7 +86,7 @@ then
 	MPI_VERSION=`$MPI_CC -v 2>&1 | grep "MPICH2 version"`
 else
 	echo $install_error_MPI_NOT_FOUND > ~/install-exit-status
-	exit $install_error_MPI_NOT_FOUND
+	exit $errno_ENOENT
 fi
 
 # Find Linear Algebra Package To Use
@@ -137,7 +138,7 @@ then
 	LA_VERSION="OpenBLAS"
 else
 	echo $install_error_LA_NOT_FOUND > ~/install-exit-status
-	exit $install_error_LA_NOT_FOUND
+	exit $errno_ENOENT
 fi
 
 if [ ! "X$MPI_VERSION" = "X" ]

--- a/pts/hpcc-1.2.8/install.sh
+++ b/pts/hpcc-1.2.8/install.sh
@@ -85,6 +85,7 @@ then
 	MPI_CC=/usr/bin/mpicc
 	MPI_VERSION=`$MPI_CC -v 2>&1 | grep "MPICH2 version"`
 else
+	echo "Error: MPI not found."
 	echo $install_error_MPI_NOT_FOUND > ~/install-exit-status
 	exit $errno_ENOENT
 fi
@@ -137,6 +138,7 @@ then
 	LA_LIBS="-L$LA_PATH -lblas"
 	LA_VERSION="OpenBLAS"
 else
+	echo "Error: A linear algebra package could not be found."
 	echo $install_error_LA_NOT_FOUND > ~/install-exit-status
 	exit $errno_ENOENT
 fi


### PR DESCRIPTION
Dear @michaellarabel:

While running `hpcc-1.2.8` on an Apple M1 Pro, the installation script couldn't find an installed Linear Algebra (LA) library—that's supported by HPCC—to pass to the linker for AArch64 platforms—even though an HPCC supported LA library was available.

This pull request improves multi-arch `hpcc` test installation by:
1. Using PTS' `OS_ARCH` variable during `hpcc`'s install-phase on supported Linux distros—i.e., Debian, Ubuntu, and Red Hat;
2. Exits the install-phase early if a required toolchain to build `hpcc` is _not_ found;
3. Writes a unique error code to `install-exit-status`; and
4. Echos a short message to the console to assist when running PTS' `debug-install`.

Please review and consider adding these improvements to the install script for `hpcc`.
Sincerely,
Tad
