### PR TITLE
`srsran-1.x`: Apply upstream repo name change

### DIFF
--- a/pts/srsran-1.0.1/downloads.xml
+++ b/pts/srsran-1.0.1/downloads.xml
@@ -3,11 +3,11 @@
 <PhoronixTestSuite>
   <Downloads>
     <Package>
-      <URL>https://github.com/srsran/srsRAN/archive/refs/tags/release_21_04.tar.gz</URL>
-      <MD5>b287d781111442e8c5ca9dd6e0650ea8</MD5>
-      <SHA256>5e0ad55fd7177618f61d157ed1d9335fcb6a6ea9feb3fcfdf96f8a8bbda62eb4</SHA256>
-      <FileName>srsRAN-release_21_04.tar.gz</FileName>
-      <FileSize>9868294</FileSize>
+      <URL>https://github.com/srsran/srsRAN_4G/archive/refs/tags/release_21_04.tar.gz</URL>
+      <MD5>d5f1581193ffa5d5c38d684485469c07</MD5>
+      <SHA256>2cf509acfc6620092abe2cddff86d524beda67b765bb6cac38e4f3b8365d3742</SHA256>
+      <FileName>srsRAN_4G-release_21_04.tar.gz</FileName>
+      <FileSize>9868907</FileSize>
     </Package>
   </Downloads>
 </PhoronixTestSuite>

--- a/pts/srsran-1.0.1/install.sh
+++ b/pts/srsran-1.0.1/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-tar -xf srsRAN-release_21_04.tar.gz
-cd srsRAN-release_21_04
+tar -xf srsRAN_4G-release_21_04.tar.gz
+cd srsRAN_4G-release_21_04
 mkdir build
 cd build
 cmake -DENABLE_GUI=OFF ..
@@ -10,7 +10,7 @@ echo $? > ~/install-exit-status
 
 cd ~
 echo "#!/bin/sh
-cd srsRAN-release_21_04/build/
+cd srsRAN_4G-release_21_04/build/
 ./\$@ 2>&1  | sed 's/Rx@/ /' > \$LOG_FILE
 echo \$? > ~/test-exit-status" > srsran
 chmod +x srsran

--- a/pts/srsran-1.1.0/downloads.xml
+++ b/pts/srsran-1.1.0/downloads.xml
@@ -3,11 +3,11 @@
 <PhoronixTestSuite>
   <Downloads>
     <Package>
-      <URL>https://github.com/srsran/srsRAN/archive/refs/tags/release_21_10.tar.gz</URL>
-      <MD5>a821f513aed2d880ae0e446a9d1cf362</MD5>
-      <SHA256>0ffc77af3822700111dac2998c15885b45ee36463065f34577d90708411c31e5</SHA256>
-      <FileName>srsRAN-release_21_10.tar.gz</FileName>
-      <FileSize>14603401</FileSize>
+      <URL>https://github.com/srsran/srsRAN_4G/archive/refs/tags/release_21_10.tar.gz</URL>
+      <MD5>1a8bb6bfd4b198c3717d3a660f99ed34</MD5>
+      <SHA256>4314595d2f00d8ba289c540a0aa71aa7e366f619f39a5bd7e3b1479f5c45cdf2</SHA256>
+      <FileName>srsRAN_4G-release_21_10.tar.gz</FileName>
+      <FileSize>14603096</FileSize>
     </Package>
   </Downloads>
 </PhoronixTestSuite>

--- a/pts/srsran-1.1.0/install.sh
+++ b/pts/srsran-1.1.0/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-tar -xf srsRAN-release_21_10.tar.gz
-cd srsRAN-release_21_10
+tar -xf srsRAN_4G-release_21_10.tar.gz
+cd srsRAN_4G-release_21_10
 mkdir build
 cd build
 cmake -DENABLE_GUI=OFF ..
@@ -10,7 +10,7 @@ echo $? > ~/install-exit-status
 
 cd ~
 echo "#!/bin/sh
-cd srsRAN-release_21_10/build/
+cd srsRAN_4G-release_21_10/build/
 ./\$@ 2>&1  | sed 's/Rx@/ /' > \$LOG_FILE
 echo \$? > ~/test-exit-status" > srsran
 chmod +x srsran

--- a/pts/srsran-1.2.0/downloads.xml
+++ b/pts/srsran-1.2.0/downloads.xml
@@ -3,11 +3,11 @@
 <PhoronixTestSuite>
   <Downloads>
     <Package>
-      <URL>https://github.com/srsran/srsRAN/archive/refs/tags/release_22_04_1.tar.gz</URL>
-      <MD5>906bb7d73418157f0d14845aeb4fc4e3</MD5>
-      <SHA256>10f76bbf6cbfea4b5c486bfbd27e97a3a8006896f6ea6416c0fef6612c88e000</SHA256>
-      <FileName>srsRAN-release_22_04_1.tar.gz</FileName>
-      <FileSize>15185749</FileSize>
+      <URL>https://github.com/srsran/srsRAN_4G/archive/refs/tags/release_22_04_1.tar.gz</URL>
+      <MD5>aa5c5cade449b94ff6b0e236f67fb730</MD5>
+      <SHA256>e599a06f9ea64e0b938eb50ce8f9fd184ebd8ebcbaabd20ac98b1997c5b41265</SHA256>
+      <FileName>srsRAN_4G-release_22_04_1.tar.gz</FileName>
+      <FileSize>15185330</FileSize>
     </Package>
   </Downloads>
 </PhoronixTestSuite>

--- a/pts/srsran-1.2.0/install.sh
+++ b/pts/srsran-1.2.0/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-tar -xf srsRAN-release_22_04_1.tar.gz
-cd srsRAN-release_22_04_1/
+tar -xf srsRAN_4G-release_22_04_1.tar.gz
+cd srsRAN_4G-release_22_04_1/
 mkdir build
 cd build
 cmake -DENABLE_GUI=OFF ..
@@ -9,7 +9,7 @@ echo $? > ~/install-exit-status
 
 cd ~
 echo "#!/bin/sh
-cd srsRAN-release_22_04_1/build/
+cd srsRAN_4G-release_22_04_1/build/
 ./\$@ 2>&1  | sed 's/Rx@/ /' > \$LOG_FILE
 echo \$? > ~/test-exit-status" > srsran
 chmod +x srsran


### PR DESCRIPTION
Dear @michaellarabel:

SRS' upstream repo name changed from `srsRAN` to `srsRAN_4G`. This PR updates the `srsran-1.x` test profiles to reflect:

1. New download file naming scheme;
2. New download file hashes;
3. New download file sizes; and
4. Revised install procedure updated to reflect changes from item 1.

Please review and update the `srsran-1.x` test profiles as needed.
Sincerely,
Tad


P.S. When testing `srsran-1.0`, please be aware that [srsRAN release 21.04 does not build with GCC 11](https://github.com/srsran/srsRAN_4G/issues/689) due to [changes made in GCC 11](https://gcc.gnu.org/gcc-11/changes.html).
- You can build with GCC 10.