### PR TITLE
pts/leveldb-1.0.3: Fix build error

### DIFF
--- a/pts/leveldb-1.0.3/downloads.xml
+++ b/pts/leveldb-1.0.3/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.0.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/google/leveldb/archive/1.22.tar.gz</URL>
+      <MD5>e1dbde14dcda1b58b49f0c214464fdd9</MD5>
+      <SHA256>55423cac9e3306f4a9502c738a001e4a339d1a38ffbee7572d4a07d5d63949b2</SHA256>
+      <FileName>leveldb-1.22.tar.gz</FileName>
+      <FileSize>239365</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/leveldb-1.0.3/install.sh
+++ b/pts/leveldb-1.0.3/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+tar -xf leveldb-1.22.tar.gz
+cd leveldb-1.22
+sed -i '4 a #include <ctime>' ./doc/bench/db_bench_sqlite3.cc
+mkdir build
+cd build
+cmake  -DCMAKE_BUILD_TYPE=Release ..
+make -j $NUM_CPU_THREADS
+echo $? > ~/install-exit-status
+
+cd ~
+
+cd ~
+echo "#!/bin/sh
+cd ~/KeyDB-5.3.1/
+cd leveldb-1.22/build
+./db_bench --threads=\$NUM_CPU_CORES \$@ > \$LOG_FILE
+" > leveldb
+chmod +x leveldb

--- a/pts/leveldb-1.0.3/results-definition.xml
+++ b/pts/leveldb-1.0.3/results-definition.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.0.1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>fillseq      :     257.528 micros/op;   #_RESULT_# MB/s    </OutputTemplate>
+    <LineHint>micros/op</LineHint>
+    <ResultScale>MB/s</ResultScale>
+    <ResultProportion>HIB</ResultProportion>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate>readhot      :      #_RESULT_# micros/op;</OutputTemplate>
+    <LineHint>micros/op</LineHint>
+    <ResultScale>Microseconds Per Op</ResultScale>
+    <ResultProportion>LIB</ResultProportion>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/leveldb-1.0.3/test-definition.xml
+++ b/pts/leveldb-1.0.3/test-definition.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.0.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>LevelDB</Title>
+    <AppVersion>1.22</AppVersion>
+    <Description>LevelDB is a key-value storage library developed by Google that supports making use of Snappy for data compression and has other modern features.</Description>
+    <ResultScale>Microseconds Per Op</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.0.2</Version>
+    <SupportedPlatforms>Linux, BSD, MacOSX</SupportedPlatforms>
+    <SoftwareType>Benchmark</SoftwareType>
+    <TestType>Disk</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, cmake, snappy</ExternalDependencies>
+    <EnvironmentSize>18</EnvironmentSize>
+    <ProjectURL>https://github.com/google/leveldb</ProjectURL>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Benchmark</DisplayName>
+      <Identifier>benchmark</Identifier>
+      <ArgumentPrefix>--benchmarks=</ArgumentPrefix>
+      <Menu>
+        <Entry>
+          <Name>Sequential Fill</Name>
+          <Value>fillseq --num=500000</Value>
+        </Entry>
+        <Entry>
+          <Name>Random Fill</Name>
+          <Value>fillrandom --num=100000</Value>
+        </Entry>
+        <Entry>
+          <Name>Overwrite</Name>
+          <Value>overwrite --num=100000</Value>
+        </Entry>
+        <Entry>
+          <Name>Fill Sync</Name>
+          <Value>fillsync --num=1000000</Value>
+        </Entry>
+        <Entry>
+          <Name>Random Read</Name>
+          <Value>readrandom --num=1000000</Value>
+        </Entry>
+        <Entry>
+          <Name>Random Delete</Name>
+          <Value>deleterandom --num=500000</Value>
+        </Entry>
+        <Entry>
+          <Name>Hot Read</Name>
+          <Value>readhot --num=1000000</Value>
+        </Entry>
+        <Entry>
+          <Name>Seek Random</Name>
+          <Value>seekrandom --num=1000000</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
When compiling with gcc 13.1.1 I get the following error:

```
/home/REDACTED/.phoronix-test-suite/installed-tests/pts/leveldb-1.0.2/leveldb-1.22/doc/bench/db_bench_sqlite3.cc:207:18: error: ‘time’ was not declared in this scope
 12   207 |     time_t now = time(nullptr);
 13       |                  ^~~~
```

This is due to a missing include of ctime.