### PR TITLE
Modify the score calculation method of OpenCV

### DIFF
--- a/pts/opencv-1.4.0/downloads.xml
+++ b/pts/opencv-1.4.0/downloads.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/opencv/opencv/archive/refs/tags/4.7.0.tar.gz</URL>
+      <MD5>13e13244cb0cc6ec4f01eacd38d05d17</MD5>
+      <SHA256>8df0079cdbe179748a18d44731af62a245a45ebf5085223dc03133954c662973</SHA256>
+      <FileName>opencv-4.7.0.tar.gz</FileName>
+      <FileSize>91027497</FileSize>
+    </Package>
+    <Package>
+      <URL>https://github.com/opencv/opencv_extra/archive/refs/tags/4.7.0.tar.gz</URL>
+      <MD5>051564e9b2b59b01fe93d9ec12525556</MD5>
+      <SHA256>835420bbd625ba73ac892bdadf247a52ac42fa26f24c2f3752f63dbb3487bbb5</SHA256>
+      <FileName>opencv_extra-4.7.0.tar.gz</FileName>
+      <FileSize>500181420</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/opencv-1.4.0/install.sh
+++ b/pts/opencv-1.4.0/install.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+tar -xf opencv-4.7.0.tar.gz
+tar -xf opencv_extra-4.7.0.tar.gz
+cd opencv-4.7.0
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DWITH_OPENCL=OFF ..
+make -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+cd ~
+
+# Get the geomean of all the tests 
+echo "import math
+file = open('data_for_all', 'r')
+data = []
+for line in file:
+    line = line.strip() 
+    data.append(float(line))
+value = math.exp(math.fsum(math.log(x) for x in data) / len(data))
+print (\"The geomean time is \", value/1000, \" ms\")" > get_geomean.py
+
+echo "#!/bin/sh
+cd opencv-4.7.0/modules/ts/misc
+export OPENCV_TEST_DATA_PATH=\$HOME/opencv_extra-4.7.0/testdata/
+python ./run.py \$HOME/opencv-4.7.0/build -t \$@ -w \$HOME
+python ./summary.py \$HOME/\$@*.xml -o txt -u mks -m mean &>\$HOME/\$@.result
+cd \$HOME
+rm \$HOME/\$@*.xml
+cat \$@.result | awk 'NR>=6{print \$NF}' > data_for_all
+python get_geomean.py > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status" > opencv
+chmod +x opencv

--- a/pts/opencv-1.4.0/results-definition.xml
+++ b/pts/opencv-1.4.0/results-definition.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>The geomean time is #_RESULT_# ms</OutputTemplate>
+    <LineHint>The geomean time is</LineHint>
+    <StripFromResult>is</StripFromResult>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/opencv-1.4.0/test-definition.xml
+++ b/pts/opencv-1.4.0/test-definition.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>OpenCV</Title>
+    <AppVersion>4.7</AppVersion>
+    <Description>This is a benchmark of the OpenCV (Computer Vision) library's built-in performance tests.</Description>
+    <ResultScale>ms</ResultScale>
+    <Proportion>LIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.3.0</Version>
+    <SupportedPlatforms>Linux</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>System</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, jpeg-development, libpng-development, cmake, opencl, vulkan-development</ExternalDependencies>
+    <EnvironmentSize>1400</EnvironmentSize>
+    <ProjectURL>https://opencv.org/</ProjectURL>
+    <RepositoryURL>https://github.com/opencv/opencv</RepositoryURL>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>libavcodec/avcodec.h, libavformat/avformat.h</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Test</DisplayName>
+      <Identifier>test</Identifier>
+      <Menu>
+        <Entry>
+          <Name>DNN - Deep Neural Network</Name>
+          <Value>dnn</Value>
+        </Entry>
+        <Entry>
+          <Name>Features 2D</Name>
+          <Value>features2d</Value>
+        </Entry>
+        <Entry>
+          <Name>Object Detection</Name>
+          <Value>objdetect</Value>
+        </Entry>
+        <Entry>
+          <Name>Core</Name>
+          <Value>core</Value>
+        </Entry>
+        <Entry>
+          <Name>Graph API</Name>
+          <Value>gapi</Value>
+        </Entry>
+        <Entry>
+          <Name>Image Processing</Name>
+          <Value>imgproc</Value>
+        </Entry>
+        <Entry>
+          <Name>Stitching</Name>
+          <Value>stitching</Value>
+        </Entry>
+        <Entry>
+          <Name>Video</Name>
+          <Value>video</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
Problem: The current score calculation method in PTS/OpenCV-1.3.0 is built without a fixed workload, such a score calculation is wrong.

The steps and methods introduced by OpenCV for performance testing are as follows:
https://github.com/opencv/opencv/wiki/HowToUsePerfTests#running-performance-tests-and-analyzing-the-results

The workload of PTS/OpenCV-1.3.0 is the total amount of time each case runs in a module, and the number of rounds each case runs is not a fixed value.
If the coefficient of variation(mean/standard deviation) of the previous rounds of the case that has been run before is greater than 3.0%, it will continue to run the next round, and if not, it will stop.
The number of rounds is determined according to stability: the coefficient of variation which is clearly indeterminate. 

Still using the tool functions provided by OpenCV. , The proposed score is composed of the geomean of the mean time of all the running cases.
