### PR TITLE
Update download link for compress-pbzip2-1.6.0

### DIFF
--- a/pts/compress-pbzip2-1.6.0/downloads.xml
+++ b/pts/compress-pbzip2-1.6.0/downloads.xml
@@ -17,7 +17,7 @@
       <FileSize>48015</FileSize>
     </Package>
     <Package>
-      <URL>https://download.freebsd.org/releases/amd64/amd64/ISO-IMAGES/13.0/FreeBSD-13.0-RELEASE-amd64-memstick.img, http://ftp.at.freebsd.org/pub/FreeBSD/releases/amd64/amd64/ISO-IMAGES/13.0/FreeBSD-13.0-RELEASE-amd64-memstick.img</URL>
+      <URL>http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/ISO-IMAGES/13.0/FreeBSD-13.0-RELEASE-amd64-memstick.img</URL>
       <MD5>e0e21f7421e26f1da29b723895f42bb8</MD5>
       <SHA256>3a1b0ef1e2211f03980eb00fdeedeb3cd9ead03f1bfcd9f6a1eb335c3b994377</SHA256>
       <FileName>FreeBSD-13.0-RELEASE-amd64-memstick.img</FileName>


### PR DESCRIPTION
The old links are not working anymore.