### PR TITLE
pts/cloverleaf-1.1.0: set optimial GOMP_SPINCOUNT for large systems

### DIFF
--- a/pts/cloverleaf-1.1.0/install.sh
+++ b/pts/cloverleaf-1.1.0/install.sh
@@ -11,7 +11,7 @@ echo "#!/bin/sh
 cd CloverLeaf_OpenMP-master/
 rm -f clover.out
 cp -f InputDecks/clover_bm.in clover.in
-OMP_NUM_THREADS=\$NUM_CPU_CORES ./clover_leaf \$@
+OMP_NUM_THREADS=\$NUM_CPU_CORES GOMP_SPINCOUNT=7000 OMP_WAIT_POLICY=active ./clover_leaf \$@
 cat clover.out > \$LOG_FILE
 echo \$? > ~/test-exit-status" > cloverleaf
 chmod +x cloverleaf


### PR DESCRIPTION
For large systems of over 80 CPUs there is a large amount of memory contention in gomp_team_barrier_wait_end that impacts on performance and unnecessarily increases run time. This can be resolved by setting GOMP_SPINCOUNT to 7000 to reduce the contention. Also ensure that the OMP_WAIT_POLICY is set to active to ensure the optimial OMP wait policy is used for larger systems.