### PR TITLE
`rabbitmq`: Add Erlang dependencies for RabbitMQ server

### DIFF
--- a/pts/rabbitmq-1.0.0/test-definition.xml
+++ b/pts/rabbitmq-1.0.0/test-definition.xml
@@ -21,7 +21,7 @@
     <ProjectURL>https://www.rabbitmq.com/</ProjectURL>
     <RepositoryURL>https://github.com/rabbitmq/rabbitmq-server</RepositoryURL>
     <Maintainer>Michael Larabel</Maintainer>
-    <SystemDependencies>inets.beam</SystemDependencies>
+    <SystemDependencies>inets.beam, make.beam, xmerl.beam, os_mon.beam, eldap.appup</SystemDependencies>
   </TestProfile>
   <TestSettings>
     <Option>

--- a/pts/rabbitmq-1.0.0/test-definition.xml
+++ b/pts/rabbitmq-1.0.0/test-definition.xml
@@ -21,7 +21,7 @@
     <ProjectURL>https://www.rabbitmq.com/</ProjectURL>
     <RepositoryURL>https://github.com/rabbitmq/rabbitmq-server</RepositoryURL>
     <Maintainer>Michael Larabel</Maintainer>
-    <SystemDependencies>erl</SystemDependencies>
+    <SystemDependencies>inets.beam</SystemDependencies>
   </TestProfile>
   <TestSettings>
     <Option>


### PR DESCRIPTION
_tl_;_dr_—Update PTS' system dependency to install the Erlang libraries required by the RabbitMQ server.

## What happens?
When PTS starts `rabbitmq-server` on Ubuntu 22.04 LTS, the server will fail to start with the following error:
```
=INFO REPORT==== 11-Nov-2023::00:02:00.179771 ===
    application: crypto
    exited: stopped
    type: transient

{"init terminating in do_boot",{error,{public_key,{"no such file or directory","public_key.app"}}}}
init terminating in do_boot ({error,{public_key,{no such file or directory,public_key.app}}})

Crash dump is being written to: erl_crash.dump...done
```

## Proposed solution
`rabbitmq-server` fails because the base Erlang package—i.e., declaring the Erlang base package (`erl`) as the sole system dependency—does _not_ include all the Erlang libraries needed to run the server.
- This pull request adds the missing Erlang libraries as PTS system dependencies:
  - Erlang Internet libraries (`inets.beam`)
  - Erlang Tools (`make.beam`)
  - Erlang XML libraries (`xmerl.beam`)
  - Erlang OS monitor (`os_mon.beam`)
  - Erlang LDAP libraries (`eldap.appup`)
