### PR TITLE
Update y-cruncher download URI to match upstream changes at NumberWorld.org

### DIFF
--- a/pts/y-cruncher-1.3.0/downloads.xml
+++ b/pts/y-cruncher-1.3.0/downloads.xml
@@ -3,7 +3,7 @@
 <PhoronixTestSuite>
   <Downloads>
     <Package>
-      <URL>http://www.numberworld.org/y-cruncher/y-cruncher%20v0.8.2.9524-static.tar.xz</URL>
+      <URL>http://www.numberworld.org/y-cruncher/old_versions/y-cruncher%20v0.8.2.9524-static.tar.xz</URL>
       <MD5>51d8287ab20936b92d6c8e7dc3e3249a</MD5>
       <SHA256>a3d65bc904ee206e143d0688ef71fb4c079a2a2ba4413e3b7b8d1faa50658932</SHA256>
       <FileName>y-cruncher-v0.8.2.9524-static.tar.xz</FileName>
@@ -11,7 +11,7 @@
       <PlatformSpecific>Linux</PlatformSpecific>
     </Package>
     <Package>
-      <URL>http://www.numberworld.org/y-cruncher/y-cruncher%20v0.8.2.9524.zip</URL>
+      <URL>http://www.numberworld.org/y-cruncher/old_versions/y-cruncher%20v0.8.2.9524.zip</URL>
       <MD5>017dafc95be6bdc04139dc5e164e62b6</MD5>
       <SHA256>bd2a8505ba02c4d0986cfd4700a98d9d06e9c93d28f350ff5387292df62abe26</SHA256>
       <FileName>y-cruncher-v0.8.2.9524.zip</FileName>


### PR DESCRIPTION
Alex Yee released [version](http://www.numberworld.org/y-cruncher/versions.html) 0.8.3 of y-cruncher—hours, or perhaps just minutes—after PTS updated y-cruncher to v0.8.2 in #299. With the release of y-cruncher v0.8.3, Alex also changed the download URI for the 0.8.2.9524 version of y-cruncher used in PTS' v1.3.0 test profile for y-cruncher.

This pull request makes the following updates to the v1.3 PTS test profile for y-cruncher:

- Updates the y-cruncher v0.8.2.9524 for Linux download URI to match changes made upstream at Alex Yee's website (Numberworld).
- Updates the y-cruncher v0.8.2.9524 for Windows download URI to match changes made upstream at Alex Yee's website (Numberworld).