### PR TITLE
Adding srsRAN Project 23.10.1 as new testsuite

### DIFF
--- a/pts/srsran-2.2.0/downloads.xml
+++ b/pts/srsran-2.2.0/downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>https://github.com/srsran/srsRAN_Project/archive/refs/tags/release_23_5.tar.gz</URL>
+      <MD5>83907c7d1f6ba907ffc2e2632dabeaf6</MD5>
+      <SHA256>f95c1f5fe4c8131e1298be7b2675e28a2a27908b21dedb1495e6f2d1087a3703</SHA256>
+      <FileName>srsRAN_Project-release_23_5.tar.gz</FileName>
+      <FileSize>4543824</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/srsran-2.2.0/downloads.xml
+++ b/pts/srsran-2.2.0/downloads.xml
@@ -3,11 +3,11 @@
 <PhoronixTestSuite>
   <Downloads>
     <Package>
-      <URL>https://github.com/srsran/srsRAN_Project/archive/refs/tags/release_23_5.tar.gz</URL>
+      <URL>https://github.com/srsran/srsRAN_Project/archive/refs/tags/release_23_10_1.tar.gz</URL>
       <MD5>83907c7d1f6ba907ffc2e2632dabeaf6</MD5>
-      <SHA256>f95c1f5fe4c8131e1298be7b2675e28a2a27908b21dedb1495e6f2d1087a3703</SHA256>
-      <FileName>srsRAN_Project-release_23_5.tar.gz</FileName>
-      <FileSize>4543824</FileSize>
+      <SHA256>fe0de257f7e541172798d76975d426990b792ddbcd93b77dd2a32ca6609ab189</SHA256>
+      <FileName>srsRAN_Project-release_23_10_1.tar.gz</FileName>
+      <FileSize>5474438</FileSize>
     </Package>
   </Downloads>
 </PhoronixTestSuite>

--- a/pts/srsran-2.2.0/install.sh
+++ b/pts/srsran-2.2.0/install.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+tar -xf srsRAN_Project-release_23_5.tar.gz
+cd srsRAN_Project-release_23_5/
+mkdir build
+cd build
+cmake -DENABLE_GUI=OFF -DCMAKE_BUILD_TYPE=Release ..
+make -j $NUM_CPU_CORES
+echo $? > ~/install-exit-status
+cd ~
+echo "#!/bin/sh
+cd srsRAN_Project-release_23_5/build/
+./\$@ 2>&1 > \$LOG_FILE
+echo \$? > ~/test-exit-status" > srsran
+chmod +x srsran

--- a/pts/srsran-2.2.0/install.sh
+++ b/pts/srsran-2.2.0/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-tar -xf srsRAN_Project-release_23_5.tar.gz
-cd srsRAN_Project-release_23_5/
+tar -xf srsRAN_Project-release_23_10_1.tar.gz
+cd srsRAN_Project-release_23_10_1/
 mkdir build
 cd build
 cmake -DENABLE_GUI=OFF -DCMAKE_BUILD_TYPE=Release ..
@@ -8,7 +8,7 @@ make -j $NUM_CPU_CORES
 echo $? > ~/install-exit-status
 cd ~
 echo "#!/bin/sh
-cd srsRAN_Project-release_23_5/build/
+cd srsRAN_Project-release_23_10_1/build/
 ./\$@ 2>&1 > \$LOG_FILE
 echo \$? > ~/test-exit-status" > srsran
 chmod +x srsran

--- a/pts/srsran-2.2.0/results-definition.xml
+++ b/pts/srsran-2.2.0/results-definition.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate> PUSCH RB=25  Mod=QPSK   R=0.117 -   0.9 Mbps|   157.3|   156.5|   154.3|   #_RESULT_#   132.1|   132.1|</OutputTemplate>
+    <LineHint>PUSCH</LineHint>
+    <MultiMatch>GEOMETRIC_MEAN</MultiMatch>
+    <ResultScale>Mbps</ResultScale>
+    <TurnCharsToSpace>|</TurnCharsToSpace>
+  </ResultsParser>
+  <ResultsParser>
+    <OutputTemplate> PDSCH BW=26  Mod=QPSK   R=0.117 -   0.9 Mbps|    55.3|    55.1|    54.5|    #_RESULT_#    50.0|    16.3|</OutputTemplate>
+    <LineHint>PDSCH</LineHint>
+    <MultiMatch>GEOMETRIC_MEAN</MultiMatch>
+    <ResultScale>Mbps</ResultScale>
+    <TurnCharsToSpace>|</TurnCharsToSpace>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/srsran-2.2.0/results-definition.xml
+++ b/pts/srsran-2.2.0/results-definition.xml
@@ -2,14 +2,14 @@
 <!--Phoronix Test Suite v10.8.4-->
 <PhoronixTestSuite>
   <ResultsParser>
-    <OutputTemplate> PUSCH RB=25  Mod=QPSK   R=0.117 -   0.9 Mbps|   157.3|   156.5|   154.3|   #_RESULT_#   132.1|   132.1|</OutputTemplate>
+    <OutputTemplate> PUSCH RB=273 Mod=256QAM R=0.926 - 639.6 Mbps|     3.4|     3.4|     3.3|   #_RESULT_#     3.2|     3.2|</OutputTemplate>
     <LineHint>PUSCH</LineHint>
     <MultiMatch>GEOMETRIC_MEAN</MultiMatch>
     <ResultScale>Mbps</ResultScale>
     <TurnCharsToSpace>|</TurnCharsToSpace>
   </ResultsParser>
   <ResultsParser>
-    <OutputTemplate> PDSCH BW=26  Mod=QPSK   R=0.117 -   0.9 Mbps|    55.3|    55.1|    54.5|    #_RESULT_#    50.0|    16.3|</OutputTemplate>
+    <OutputTemplate> PDSCH RB=270 Mod=256QAM rv=0 - 1737.2 Mbps|    23.0|    22.9|    22.7|   #_RESULT_#    22.7|    22.7|</OutputTemplate>
     <LineHint>PDSCH</LineHint>
     <MultiMatch>GEOMETRIC_MEAN</MultiMatch>
     <ResultScale>Mbps</ResultScale>

--- a/pts/srsran-2.2.0/test-definition.xml
+++ b/pts/srsran-2.2.0/test-definition.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v10.8.4-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>srsRAN Project</Title>
+    <AppVersion>23.5</AppVersion>
+    <Description>srsRAN Project is a complete ORAN-native 5G RAN solution created by Software Radio Systems (SRS). The srsRAN Project radio suite was formerly known as srsLTE and can be used for building your own software-defined radio (SDR) 4G/5G mobile network.</Description>
+    <ResultScale>Mb/s</ResultScale>
+    <Proportion>HIB</Proportion>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>2.1.0</Version>
+    <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities, fftw3-development, cmake, boost-development, libconfigpp</ExternalDependencies>
+    <EnvironmentSize>294</EnvironmentSize>
+    <ProjectURL>https://www.srsran.com/</ProjectURL>
+    <RepositoryURL>https://github.com/srsran/srsRAN_Project</RepositoryURL>
+    <Maintainer>Michael Larabel</Maintainer>
+    <SystemDependencies>libbladeRF.h, mbedtls/aes.h, libmbedtls.so, libboost_program_options.so, /usr/include/libconfig.h++, libconfig++.so, netinet/sctp.h, libsctp.so, yaml-cpp/yaml.h, libgtest.a, gtest/gtest.h</SystemDependencies>
+  </TestProfile>
+  <TestSettings>
+    <Option>
+      <DisplayName>Test</DisplayName>
+      <Identifier>test</Identifier>
+      <Menu>
+        <Entry>
+          <Name>PUSCH Processor Benchmark, Throughput Total</Name>
+          <Value>tests/benchmarks/phy/upper/channel_processors/pusch_processor_benchmark -m throughput_total -R 100 -P pusch_scs15_50MHz_256qam_max</Value>
+        </Entry>
+        <Entry>
+          <Name>PUSCH Processor Benchmark, Throughput Thread</Name>
+          <Value>tests/benchmarks/phy/upper/channel_processors/pusch_processor_benchmark -m throughput_thread -R 100 -P pusch_scs15_50MHz_256qam_max -T 1</Value>
+        </Entry>
+        <Entry>
+          <Name>Downlink Processor Benchmark</Name>
+          <Value>tests/benchmarks/phy/upper/downlink_processor_benchmark -R 50000 -P pdsch_scs15_50MHz_256qam_max</Value>
+        </Entry>
+      </Menu>
+    </Option>
+  </TestSettings>
+</PhoronixTestSuite>

--- a/pts/srsran-2.2.0/test-definition.xml
+++ b/pts/srsran-2.2.0/test-definition.xml
@@ -3,14 +3,14 @@
 <PhoronixTestSuite>
   <TestInformation>
     <Title>srsRAN Project</Title>
-    <AppVersion>23.5</AppVersion>
+    <AppVersion>23.10.1</AppVersion>
     <Description>srsRAN Project is a complete ORAN-native 5G RAN solution created by Software Radio Systems (SRS). The srsRAN Project radio suite was formerly known as srsLTE and can be used for building your own software-defined radio (SDR) 4G/5G mobile network.</Description>
     <ResultScale>Mb/s</ResultScale>
     <Proportion>HIB</Proportion>
     <TimesToRun>3</TimesToRun>
   </TestInformation>
   <TestProfile>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <SupportedPlatforms>Linux, MacOSX</SupportedPlatforms>
     <SoftwareType>Utility</SoftwareType>
     <TestType>Processor</TestType>
@@ -30,15 +30,19 @@
       <Menu>
         <Entry>
           <Name>PUSCH Processor Benchmark, Throughput Total</Name>
-          <Value>tests/benchmarks/phy/upper/channel_processors/pusch_processor_benchmark -m throughput_total -R 100 -P pusch_scs15_50MHz_256qam_max</Value>
+          <Value>tests/benchmarks/phy/upper/channel_processors/pusch_processor_benchmark -m throughput_total -R 100 -B 10 -P pusch_scs30_100MHz_256qam_max</Value>
         </Entry>
         <Entry>
           <Name>PUSCH Processor Benchmark, Throughput Thread</Name>
-          <Value>tests/benchmarks/phy/upper/channel_processors/pusch_processor_benchmark -m throughput_thread -R 100 -P pusch_scs15_50MHz_256qam_max -T 1</Value>
+          <Value>tests/benchmarks/phy/upper/channel_processors/pusch_processor_benchmark -m throughput_thread -R 100 -B 10 -T 1 -t 0 -P pusch_scs30_100MHz_256qam_max</Value>
         </Entry>
         <Entry>
-          <Name>Downlink Processor Benchmark</Name>
-          <Value>tests/benchmarks/phy/upper/downlink_processor_benchmark -R 50000 -P pdsch_scs15_50MHz_256qam_max</Value>
+          <Name>PDSCH Processor Benchmark, Throughput Total</Name>
+          <Value>tests/benchmarks/phy/upper/pdsch_processor_benchmark -m throughput_total -R 100 -B 10 -P 4port_4layer_scs30_100MHz_256qam</Value>
+        </Entry>
+        <Entry>
+          <Name>PDSCH Processor Benchmark, Throughput Thread</Name>
+          <Value>tests/benchmarks/phy/upper/pdsch_processor_benchmark -m throughput_thread -R 100 -B 10 -T 1 -P 4port_4layer_scs30_100MHz_256qam</Value>
         </Entry>
       </Menu>
     </Option>


### PR DESCRIPTION
Hey @michaellarabel 

this PR bumps the srsRAN release for 23.10.1 and also add parallel tests for the DL. I've noticed the current results are quite outdated and don't have the parallel downlink tests enabled.

Let me know if you need any further information.

Thanks
