### PR TITLE
pts/namd-1.3.1: add tuning for Linux NUMA systems

### DIFF
--- a/pts/namd-1.3.1/install.sh
+++ b/pts/namd-1.3.1/install.sh
@@ -12,5 +12,5 @@ then
 else
 	cd NAMD_3.0b6_Linux-x86_64-multicore
 fi
-./namd3 +p\$NUM_CPU_CORES +setcpuaffinity \$@ > \$LOG_FILE 2>&1" > namd
+./namd3 +p\$NUM_CPU_CORES +setcpuaffinity +maffinity +CmiSleepOnIdle \$@ > \$LOG_FILE 2>&1" > namd
 chmod +x namd


### PR DESCRIPTION
NUMA Linux systems benefit from adding the memory affinity +maffinity option and this won't affect non-NUMA performance. On large multi-CPU systems adding +CmiSleepOnIdle reduces the threaded spinlock impact across shared memory and reduces the jitter of the metrics and also helps NUMA systems too.