### PR TITLE
pts/mt-dgemm-1.3.0: Update to benchmark the OpenBLAS performance

### DIFF
--- a/pts/mt-dgemm-1.3.0/downloads.xml
+++ b/pts/mt-dgemm-1.3.0/downloads.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <Downloads>
+    <Package>
+      <URL>http://phoronix-test-suite.com/benchmark-files/mtdgemm-crossroads-v1.0.0.tgz</URL>
+      <MD5>b133bd78e7864cef498f92b03176cafd</MD5>
+      <SHA256>ba0a6222ae82e89ec3e2c26b22f2d4d9999993f436d9980c57b0ade660d12649</SHA256>
+      <FileName>mtdgemm-crossroads-v1.0.0.tgz</FileName>
+      <FileSize>4082</FileSize>
+    </Package>
+    <Package>
+      <URL>https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.21/OpenBLAS-0.3.21.tar.gz</URL>
+      <MD5>ffb6120e2309a2280471716301824805</MD5>
+      <SHA256>f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca</SHA256>
+      <FileName>OpenBLAS-0.3.21.tar.gz</FileName>
+      <FileSize>23729571</FileSize>
+    </Package>
+  </Downloads>
+</PhoronixTestSuite>

--- a/pts/mt-dgemm-1.3.0/install.sh
+++ b/pts/mt-dgemm-1.3.0/install.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+tar -xf OpenBLAS-0.3.21.tar.gz
+tar -xf mtdgemm-crossroads-v1.0.0.tgz
+
+mkdir $HOME/openblas_
+
+cd OpenBLAS-0.3.21
+make USE_THREAD=1 USE_OPENMP=1 DYNAMIC_ARCH=1 -j $NUM_CPU_CORES
+make PREFIX=$HOME/openblas_ USE_THREAD=1 USE_OPENMP=1 DYNAMIC_ARCH=1 install
+cd ..
+
+cc -ffast-math -mavx2 -ftree-vectorizer-verbose=3 -O3 -fopenmp -DUSE_CBLAS -I./openblas_/include -o mtdgemm mt-dgemm/src/mt-dgemm.c -L./openblas_/lib -lopenblas
+echo $? > ~/install-exit-status
+rm -rf mt-dgemm
+
+echo "#!/bin/sh
+export OMP_NUM_THREADS=\$NUM_CPU_CORES
+export OMP_PLACES=cores
+export OMP_PROC_BIND=close
+export LD_LIBRARY_PATH=./openblas_/lib:\$LD_LIBRARY_PATH
+./mtdgemm \$@ > \$LOG_FILE 2>&1
+echo \$? > ~/test-exit-status" > mt-dgemm
+chmod +x mt-dgemm

--- a/pts/mt-dgemm-1.3.0/results-definition.xml
+++ b/pts/mt-dgemm-1.3.0/results-definition.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <ResultsParser>
+    <OutputTemplate>GFLOP/s rate:         #_RESULT_# GF/s</OutputTemplate>
+  </ResultsParser>
+</PhoronixTestSuite>

--- a/pts/mt-dgemm-1.3.0/test-definition.xml
+++ b/pts/mt-dgemm-1.3.0/test-definition.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--Phoronix Test Suite v9.0.1-->
+<PhoronixTestSuite>
+  <TestInformation>
+    <Title>ACES DGEMM</Title>
+    <AppVersion>1.0</AppVersion>
+    <Description>This is a multi-threaded DGEMM benchmark.</Description>
+    <ResultScale>GFLOP/s</ResultScale>
+    <Proportion>HIB</Proportion>
+    <SubTitle>Sustained Floating-Point Rate</SubTitle>
+    <TimesToRun>3</TimesToRun>
+  </TestInformation>
+  <TestProfile>
+    <Version>1.3.0</Version>
+    <SupportedPlatforms>Linux, Solaris, MacOSX, BSD</SupportedPlatforms>
+    <SoftwareType>Utility</SoftwareType>
+    <TestType>Processor</TestType>
+    <License>Free</License>
+    <Status>Verified</Status>
+    <ExternalDependencies>build-utilities</ExternalDependencies>
+    <EnvironmentSize>1</EnvironmentSize>
+    <ProjectURL>https://www.lanl.gov/projects/crossroads/benchmarks-performance-analysis.php</ProjectURL>
+    <InternalTags>SMP</InternalTags>
+    <Maintainer>Michael Larabel</Maintainer>
+  </TestProfile>
+  <TestSettings>
+    <Default>
+      <Arguments>3072 4</Arguments>
+    </Default>
+  </TestSettings>
+</PhoronixTestSuite>


### PR DESCRIPTION
The mt-dgemm benchmark is designed to evaluate the efficiency of matrix multiplication across three distinct implementations:

1. The native, straightforward implementation provided within the benchmark.
2. The `cblas_dgemm` subroutine from the widely respected OpenBLAS library.
3. The `dgemm` subroutine from the IBM-specific ESSL library.

Our previous version, pts/mt-dgemm-1.2.0, focused exclusively on the native implementation for performance measurement. However, recent performance evaluations have revealed several limitations with the naive approach:

1. It does not effectively utilize AVX (Advanced Vector Extensions), which is critical for optimizing performance on modern processors.
2. It suffers from significant memory-bound issues, impacting overall execution speed.

In contrast, the matrix multiplication routine in OpenBLAS has been meticulously optimized to circumvent these issues, resulting in substantially improved performance metrics. Given the importance of these optimizations in reflecting real-world application performance, we propose to incorporate the OpenBLAS-based implementation into our benchmark suite.

This change is expected to provide a more accurate representation of performance as experienced by end-users, aligning our benchmark with industry standards and customer expectations.