### PR TITLE
Fix 'multiple definition' error when install netperf.

### DIFF
--- a/pts/netperf-1.0.4/install.sh
+++ b/pts/netperf-1.0.4/install.sh
@@ -107,6 +107,43 @@ EOT
 	patch -p1 < 328fe3b56a8753f6f700aac2b2df84dda5ce93a3.patch
 fi
 
+# https://github.com/HewlettPackard/netperf/commit/c6a2e17fe35f0e68823451fedfdf5b1dbecddbe3.patch
+cat > c6a2e17fe35f0e68823451fedfdf5b1dbecddbe3.patch <<EOT
+From c6a2e17fe35f0e68823451fedfdf5b1dbecddbe3 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 12 Aug 2020 09:57:23 -0700
+Subject: [PATCH] nettest_omni: Remove duplicate variable definitions
+
+These defines are already defined in nettest_bsd.c and exported by
+nettest_bsd.h this should fix build with -fno-common
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/nettest_omni.c | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/src/nettest_omni.c b/src/nettest_omni.c
+index 852eeb1..862088a 100644
+--- a/src/nettest_omni.c
++++ b/src/nettest_omni.c
+@@ -458,14 +458,6 @@ static int client_port_max = 65535;
+
+  /* different options for the sockets                          */
+
+-int
+-  loc_nodelay,         /* don't/do use NODELAY locally         */
+-  rem_nodelay,         /* don't/do use NODELAY remotely        */
+-  loc_sndavoid,                /* avoid send copies locally            */
+-  loc_rcvavoid,                /* avoid recv copies locally            */
+-  rem_sndavoid,                /* avoid send copies remotely           */
+-  rem_rcvavoid;        /* avoid recv_copies remotely           */
+-
+ extern int
+   loc_tcpcork,
+   rem_tcpcork,
+EOT
+patch -p1 < c6a2e17fe35f0e68823451fedfdf5b1dbecddbe3.patch
+
 ./configure CFLAGS="$CFLAGS"
 make -j $NUM_CPU_CORES
 echo $? > ~/install-exit-status


### PR DESCRIPTION
`phoronix-test-suite install-test netperf` on CentOS Stream 9.

```
/usr/bin/ld: nettest_omni.o:(.bss+0x4238): multiple definition of `loc_nodelay'; nettest_bsd.o:(.bss+0x28): first defined here
/usr/bin/ld: nettest_omni.o:(.bss+0x4234): multiple definition of `rem_nodelay'; nettest_bsd.o:(.bss+0x24): first defined here
/usr/bin/ld: nettest_omni.o:(.bss+0x422c): multiple definition of `loc_rcvavoid'; nettest_bsd.o:(.bss/usr/bin/ld+0x14: ): first defined here
/usr/bin/ld: nettest_omni.o:(.bss+0x4224): multiple definition of `rem_rcvavoid'; nettest_bsd.o:(.bss+0xc): first defined here
/usr/bin/ld: nettest_omni.o:(.bss+0x4228): multiple definition of `rem_sndavoid'; nettest_bsd.o:(.bss+0x10): first defined here
nettest_omni.o:/usr/bin/ld(: .bss+0xnettest_omni.o:(.bss+0x42304238): multiple definition of `)loc_sndavoid: multiple definition of `'; loc_nodelay'; nettest_bsd.o:(.bss+0x18): first defined here
nettest_bsd.o:(.bss+0x28): first defined here
/usr/bin/ld: nettest_omni.o:(.bss+0x4234): multiple definition of `rem_nodelay'; nettest_bsd.o:(.bss+0x24): first defined here
/usr/bin/ld: nettest_omni.o:(.bss+0x422c): multiple definition of `loc_rcvavoid'; nettest_bsd.o:(.bss+0x14): first defined here
/usr/bin/ld: nettest_omni.o:(.bss+0x4224): multiple definition of `rem_rcvavoid'; nettest_bsd.o:(.bss+0xc): first defined here
/usr/bin/ld: nettest_omni.o:(.bss+0x4228): multiple definition of `rem_sndavoid'; nettest_bsd.o:(.bss+0x10): first defined here
/usr/bin/ld: nettest_omni.o:(.bss+0x4230): multiple definition of `loc_sndavoid'; nettest_bsd.o:(.bss+0x18): first defined here
collect2: error: ld returned 1 exit status
collect2: error: ld returned 1 exit status
make[3]: *** [Makefile:305: netperf] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: *** [Makefile:308: netserver] Error 1
make[3]: Leaving directory '~/.phoronix-test-suite/installed-tests/pts/netperf-1.0.4/netperf-2.7.0/src'
make[2]: *** [Makefile:352: all-recursive] Error 1
make[2]: Leaving directory '~/.phoronix-test-suite/installed-tests/pts/netperf-1.0.4/netperf-2.7.0/src'
make[1]: *** [Makefile:277: all-recursive] Error 1
make[1]: Leaving directory '~/.phoronix-test-suite/installed-tests/pts/netperf-1.0.4/netperf-2.7.0'
make: *** [Makefile:215: all] Error 2

The installer exited with a non-zero exit status.

ERROR: collect2: error: ld returned 1 exit status

LOG: ~/.phoronix-test-suite/installed-tests/pts/netperf-1.0.4/install-failed.log
```