### PR TITLE
pts/cs2-1.0.0: Parse new results file

### DIFF
--- a/pts/cs2-1.0.0/install.sh
+++ b/pts/cs2-1.0.0/install.sh
@@ -4,10 +4,10 @@ unzip -o cs2-pts29.zip
 mv pts29.dem $DEBUG_REAL_HOME/.steam/steam/steamapps/common/Counter-Strike\ Global\ Offensive/game/csgo
 echo "#!/bin/bash
 cd \$DEBUG_REAL_HOME/.steam/steam/steamapps/common/Counter-Strike\ Global\ Offensive/game/csgo
-echo \"\" > Source2Bench.csv
+echo \"\" > Source2BenchV2.csv
 HOME=\$DEBUG_REAL_HOME steam -applaunch 730 \$@
 sleep 15
-tail -f  Source2Bench.csv | sed '/pts29/ q'
+tail -f  Source2BenchV2.csv | sed '/pts29/ q'
 sleep 1
-cat Source2Bench.csv >> \$LOG_FILE" > cs2
+cat Source2BenchV2.csv >> \$LOG_FILE" > cs2
 chmod +x cs2

--- a/pts/cs2-1.0.0/results-definition.xml
+++ b/pts/cs2-1.0.0/results-definition.xml
@@ -2,7 +2,7 @@
 <!--Phoronix Test Suite v10.8.4-->
 <PhoronixTestSuite>
   <ResultsParser>
-    <OutputTemplate>pts29.dem #_RESULT_# </OutputTemplate>
+    <OutputTemplate>Tue Nov 12 00:23:10 2024,pts29.dem,, #_RESULT_#, 12.4, 79.1,  5.6,  7.2,  9.1, 10652,800,600,RGBA8888,RENDER_SYSTEM_DLL_VULKAN,110,AMD Radeon RX 580 Series (RADV POLARIS10),0x1002,0x67df,enabled,3,2,"/home/user/.steam/debian-installation/steamapps/common/Counter-Strike Global Offensive/game/bin/linuxsteamrt64/cs2" "/home/user/.steam/debian-installation/steamapps/common/Counter-Strike Global Offensive/game/bin/linuxsteamrt64/cs2" -steam +cl_showfps 1 +timedemoquit pts29 +fps_max 0 -autoconfig_level 3 -high -novid -fullscreen -vulkan -w 800 -h 600,</OutputTemplate>
     <LineHint>.dem</LineHint>
     <FileFormat>CSV</FileFormat>
   </ResultsParser>


### PR DESCRIPTION
**I propose to update the results format and filename to match some recent CS2 update.
Otherwise no results are able to be parsed from this test.**

The reason being that benchmark results are now saved to _Source2Bench**V2**.csv_, with a new format.
This format is similar to that of the current Dota 2 test-profile.

I have tested the proposed fix on two different machines.