### PR TITLE
pts/leveldb-1.1.0: Pull in third_party libs and use cmake to build

### DIFF
--- a/pts/leveldb-1.1.0/downloads.xml
+++ b/pts/leveldb-1.1.0/downloads.xml
@@ -9,5 +9,20 @@
       <FileName>leveldb-1.23.tar.gz</FileName>
       <FileSize>242925</FileSize>
     </Package>
+    <Package>
+      <URL>https://github.com/google/benchmark/archive/refs/tags/v1.8.0.tar.gz</URL>
+      <MD5>8ddf8571d3f6198d37852bcbd964f817</MD5>
+      <SHA256>ea2e94c24ddf6594d15c711c06ccd4486434d9cf3eca954e2af8a20c88f9f172</SHA256>
+      <FileName>benchmark-1.8.0.tar.gz</FileName>
+      <FileSize>204701</FileSize>
+    </Package>
+    <Package>
+      <URL>https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz</URL>
+      <MD5>e8a8df240b6938bb6384155d4c37d937</MD5>
+      <SHA256>b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5</SHA256>
+      <FileName>googletest-1.11.0.tar.gz</FileName>
+      <FileSize>886330</FileSize>
+    </Package>
+
   </Downloads>
 </PhoronixTestSuite>

--- a/pts/leveldb-1.1.0/install.sh
+++ b/pts/leveldb-1.1.0/install.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 tar -xf leveldb-1.23.tar.gz
 cd leveldb-1.23
+tar xf ../googletest-1.11.0.tar.gz -C third_party/googletest --strip-components=1
+tar xf ../benchmark-1.8.0.tar.gz -C third_party/benchmark --strip-components=1
 sed -i '4 a #include <ctime>' ./benchmarks/db_bench_sqlite3.cc
-sed -i '299d' CMakeLists.txt
-sed -i '304d' CMakeLists.txt
 mkdir build
 cd build
-cmake  -DCMAKE_BUILD_TYPE=Release -DLEVELDB_BUILD_TESTS=OFF ..
-make -j $NUM_CPU_THREADS
+cmake  -DCMAKE_BUILD_TYPE=Release ..
+cmake --build .
 echo $? > ~/install-exit-status
 cd ~
 echo "#!/bin/sh


### PR DESCRIPTION
leveldb-1.1.0 doesn't build against gmock in the ubuntu repos (tested on Ubuntu 24.04.2 LTS). This change will pull in the third-party libs that are submodules in the leveldb repo's [third_party folder](https://github.com/google/leveldb/tree/main/third_party) and allows it to build successfully.

Also, this uses `cmake --build`, rather than make to build the target.